### PR TITLE
Add support for int-variables

### DIFF
--- a/src/attackmate/baseexecutor.py
+++ b/src/attackmate/baseexecutor.py
@@ -185,13 +185,15 @@ class BaseExecutor:
                 self.logger.warn(
                         f"Re-run command because loop_if matches: {m.group(0)}"
                         )
-                if self.run_count < command.loop_count:
+                if self.run_count < self.variable_to_int("loop_count", command.loop_count):
                     self.run_count = self.run_count + 1
                     time.sleep(self.cmdconfig.loop_sleep)
                     self.exec(command)
                 else:
                     self.logger.error("Exitting because loop_count exceeded")
                     exit(1)
+            else:
+                self.logger.debug("loop_if does not match")
 
     def loop_if_not(self, command: BaseCommand, result: Result):
         if command.loop_if_not is not None:
@@ -200,13 +202,21 @@ class BaseExecutor:
                 self.logger.warn(
                         "Re-run command because loop_if_not does not match"
                         )
-                if self.run_count < command.loop_count:
+                if self.run_count < self.variable_to_int("loop_count", command.loop_count):
                     self.run_count = self.run_count + 1
                     time.sleep(self.cmdconfig.loop_sleep)
                     self.exec(command)
                 else:
                     self.logger.error("Exitting because loop_count exceeded")
                     exit(1)
+            else:
+                self.logger.debug("loop_if_not does not match")
+
+    def variable_to_int(self, variablename: str, value: str) -> int:
+        if value.isnumeric():
+            return int(value)
+        else:
+            raise ExecException(f"Variable {variablename} has not a numeric value: {value}")
 
     def _exec_cmd(self, command: Any) -> Result:
         return Result(None, None)

--- a/src/attackmate/msfexecutor.py
+++ b/src/attackmate/msfexecutor.py
@@ -79,7 +79,7 @@ class MsfModuleExecutor(BaseExecutor):
         if exploit.missing_required:
             raise ExecException(f"Missing required exploit options: {exploit.missing_required}")
 
-        exploit.target = command.target
+        exploit.target = self.variable_to_int("target", command.target)
         return exploit
 
     def _exec_cmd(self, command: MsfModuleCommand) -> Result:

--- a/src/attackmate/schemas.py
+++ b/src/attackmate/schemas.py
@@ -1,7 +1,9 @@
 from typing import List, Literal, Union, Optional, Dict
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # https://stackoverflow.com/questions/71539448/using-different-pydantic-models-depending-on-the-value-of-fields
+
+VAR_PATTERN = r'^\$[$a-zA-Z0-9_]+$|^[0-9]+$'
 
 
 class BaseCommand(BaseModel):
@@ -29,7 +31,7 @@ class BaseCommand(BaseModel):
     error_if_not: Optional[str] = None
     loop_if: Optional[str] = None
     loop_if_not: Optional[str] = None
-    loop_count: int = 3
+    loop_count: str = Field(pattern=VAR_PATTERN, default="3")
     exit_on_error: bool = True
     save: Optional[str] = None
     cmd: str
@@ -37,8 +39,8 @@ class BaseCommand(BaseModel):
 
 class SleepCommand(BaseCommand):
     type: Literal['sleep']
-    min_sec: int = 0
-    seconds: int = 1
+    min_sec: str = Field(pattern=VAR_PATTERN, default="0")
+    seconds: str = Field(pattern=VAR_PATTERN, default="1")
     random: bool = False
     cmd: str = "sleep"
 
@@ -85,7 +87,7 @@ class RegExCommand(BaseCommand):
 
 class SSHBase(BaseCommand):
     hostname: Optional[str]
-    port: Optional[int]
+    port: Optional[str] = Field(pattern=VAR_PATTERN, default=None)
     username: Optional[str]
     password: Optional[str]
     passphrase: Optional[str]
@@ -95,7 +97,7 @@ class SSHBase(BaseCommand):
     clear_cache: bool = False
     timeout: float = 60
     jmp_hostname: Optional[str]
-    jmp_port: Optional[int]
+    jmp_port: Optional[str] = Field(pattern=VAR_PATTERN, default=None)
     jmp_username: Optional[str]
 
 
@@ -103,7 +105,7 @@ class SSHCommand(SSHBase):
     type: Literal['ssh']
     interactive: bool = False
     validate_prompt: bool = True
-    command_timeout: int = 15
+    command_timeout: str = Field(pattern=VAR_PATTERN, default="15")
     prompts: List[str] = ["$ ", "# ", "> "]
 
 
@@ -128,7 +130,7 @@ class MsfSessionCommand(BaseCommand):
 class MsfModuleCommand(BaseCommand):
     cmd: str
     type: Literal['msf-module']
-    target: int = 0
+    target: str = Field(pattern=VAR_PATTERN, default="0")
     creates_session: Optional[str]
     session: Optional[str]
     payload: Optional[str]
@@ -174,16 +176,16 @@ class SliverHttpsListenerCommand(BaseCommand):
     type: Literal['sliver']
     cmd: Literal['start_https_listener']
     host: str = "0.0.0.0"
-    port: int = 443
+    port: str = Field(pattern=VAR_PATTERN, default="443")
     domain: str = ""
     website: str = ""
     acme: bool = False
     persistent: bool = False
     enforce_otp: bool = True
     randomize_jarm: bool = True
-    long_poll_timeout: int = 1
-    long_poll_jitter: int = 2
-    timeout: int = 60
+    long_poll_timeout: str = Field(pattern=VAR_PATTERN, default="1")
+    long_poll_jitter: str = Field(pattern=VAR_PATTERN, default="2")
+    timeout: str = Field(pattern=VAR_PATTERN, default="60")
 
 
 class SliverGenerateCommand(BaseCommand):
@@ -270,7 +272,7 @@ class SliverSessionLSCommand(SliverSessionCommand):
 class SliverSessionPROCDUMPCommand(SliverSessionCommand):
     cmd: Literal['process_dump']
     local_path: str
-    pid: int
+    pid: str = Field(pattern=VAR_PATTERN)
 
 
 class SliverSessionRMCommand(SliverSessionCommand):
@@ -282,7 +284,7 @@ class SliverSessionRMCommand(SliverSessionCommand):
 
 class SliverSessionTERMINATECommand(SliverSessionCommand):
     cmd: Literal['terminate']
-    pid: int
+    pid: str = Field(pattern=VAR_PATTERN)
     force: bool = False
 
 

--- a/src/attackmate/sleepexecutor.py
+++ b/src/attackmate/sleepexecutor.py
@@ -11,9 +11,10 @@ class SleepExecutor(BaseExecutor):
 
     def set_sleeptime(self, command):
         if self.sleep_time is None:
-            self.sleep_time = command.seconds
+            self.sleep_time = self.variable_to_int("seconds", command.seconds)
             if command.random:
-                self.sleep_time = randint(command.min_sec, command.seconds)
+                self.sleep_time = randint(self.variable_to_int("min_sec", command.min_sec),
+                                          self.variable_to_int("seconds", command.seconds))
 
     def log_command(self, command):
         self.set_sleeptime(command)

--- a/src/attackmate/sliverexecutor.py
+++ b/src/attackmate/sliverexecutor.py
@@ -39,7 +39,7 @@ class SliverExecutor(BaseExecutor):
         if self.client is None:
             raise ExecException("SliverClient is not defined")
         listener = await self.client.start_https_listener(command.host,
-                                                          command.port,
+                                                          self.variable_to_int("port", command.port),
                                                           command.website,
                                                           command.domain,
                                                           b"",
@@ -48,9 +48,11 @@ class SliverExecutor(BaseExecutor):
                                                           command.persistent,
                                                           command.enforce_otp,
                                                           command.randomize_jarm,
-                                                          command.long_poll_timeout,
-                                                          command.long_poll_jitter,
-                                                          command.timeout)
+                                                          self.variable_to_int("long_poll_timeout",
+                                                                               command.long_poll_timeout),
+                                                          self.variable_to_int("long_poll_jitter",
+                                                                               command.long_poll_jitter),
+                                                          self.variable_to_int("timeout", command.timeout))
         self.result = Result(f"JobID: {listener.JobID}", 0)
 
     def prepare_implant_config(self, command: SliverGenerateCommand) -> client_pb2.ImplantConfig:

--- a/src/attackmate/sliversessionexecutor.py
+++ b/src/attackmate/sliversessionexecutor.py
@@ -146,7 +146,7 @@ class SliverSessionExecutor(BaseExecutor):
     async def process_dump(self, command: SliverSessionPROCDUMPCommand):
         session = await self.get_session_by_name(command.session)
         self.logger.debug(session)
-        dump = await session.process_dump(command.pid)
+        dump = await session.process_dump(self.variable_to_int("pid", command.pid))
         with open(command.local_path, "wb") as new_file:
             new_file.write(dump.Data)
 
@@ -203,7 +203,7 @@ class SliverSessionExecutor(BaseExecutor):
     async def terminate(self, command: SliverSessionTERMINATECommand):
         session = await self.get_session_by_name(command.session)
         self.logger.debug(session)
-        term = await session.terminate(command.pid, command.force)
+        term = await session.terminate(self.variable_to_int("pid", command.pid), command.force)
         self.logger.debug(term)
         self.result = Result(f"Terminated process {term.Pid}", 0)
 

--- a/src/attackmate/sshexecutor.py
+++ b/src/attackmate/sshexecutor.py
@@ -42,7 +42,7 @@ class SSHExecutor(BaseExecutor):
         if command.hostname:
             self.hostname = command.hostname
         if command.port:
-            self.port = command.port
+            self.port = self.variable_to_int("port", command.port)
         if command.username:
             self.username = command.username
         if command.password:
@@ -56,7 +56,7 @@ class SSHExecutor(BaseExecutor):
         if command.jmp_hostname:
             self.jmp_hostname = command.jmp_hostname
         if command.jmp_port:
-            self.jmp_port = command.jmp_port
+            self.jmp_port = self.variable_to_int("jmp_port", command.jmp_port)
         if command.jmp_username:
             self.jmp_username = command.jmp_username
 
@@ -198,7 +198,7 @@ class SSHExecutor(BaseExecutor):
                 if command.interactive:
                     stdin, stdout, stderr = self.exec_interactive_command(command, client)
                     self.set_timer()
-                    while self.check_timer(command.command_timeout):
+                    while self.check_timer(self.variable_to_int("timeout", command.command_timeout)):
                         if stdout.channel.recv_ready():
                             tmp = stdout.channel.recv(1025).decode("utf-8", "ignore")
                             output += tmp


### PR DESCRIPTION
This commit changes int variables of commands to
string variables with a regex-validator to check if numeric only or variable with $-sign at the beginning. This commit adds further a variable_to_int-function to the baseexecutor that checks if the value is numeric after resolving the variable.

fixes #12 