### PR TITLE
Handle empty config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,8 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
 playbooks/
 .penpal.yml
 .attackmate.yml

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -65,7 +65,8 @@ def parse_config(config_file: Optional[str], logger: logging.Logger) -> Config:
     This parser reads the configfile and validates the settings.
     If config_file is None, this function will try to load the
     config from ".attackmate.yml", "$HOME/.config/attackmate.yml" and
-    "/etc/attackmate.yml"
+    "/etc/attackmate.yml". If no files are found or the files are empty,
+    it uses default config variables.
 
     Parameters
     ----------
@@ -87,16 +88,22 @@ def parse_config(config_file: Optional[str], logger: logging.Logger) -> Config:
             for file in default_cfg_path:
                 cfg = None
                 try:
+                    if os.path.getsize(file) == 0:
+                        logger.debug(f'Config file {file} is empty. Using default config.')
+                        return Config()
                     cfg = load_configfile(file)
                 except OSError:
                     pass
                 if cfg is not None:
-                    logger.debug(f'Cfgfile {file} loaded')
+                    logger.debug(f'Config file {file} loaded')
                     return cfg
-            logger.debug('No config-file found. Using empty default-config')
+            logger.debug('No config-file found. Using default-config')
             return Config()
         else:
-            logger.debug(f'Cfgfile {config_file} loaded')
+            if os.path.getsize(config_file) == 0:
+                logger.debug(f'Config file {config_file} is empty. Using default config.')
+                return Config()
+            logger.debug(f'Config file {config_file} loaded')
             return load_configfile(config_file)
     except OSError:
         logger.error(f'Error: Could not open file {config_file}')

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -89,15 +89,14 @@ def parse_config(config_file: Optional[str], logger: logging.Logger) -> Config:
                 cfg = None
                 try:
                     if os.path.getsize(file) == 0:
-                        logger.debug(f'Config file {file} is empty. Using default config.')
-                        return Config()
+                        continue
                     cfg = load_configfile(file)
                 except OSError:
                     pass
                 if cfg is not None:
                     logger.debug(f'Config file {file} loaded')
                     return cfg
-            logger.debug('No config-file found. Using default-config')
+            logger.debug('No config-file found or the default attackmate.yml was empty. Using default-config')
             return Config()
         else:
             if os.path.getsize(config_file) == 0:

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -59,6 +59,16 @@ def load_configfile(config_file: str) -> Config:
         return Config.model_validate(config)
 
 
+def is_effectively_empty(file_path: str) -> bool:
+    """strip the contents of the file from comments and whitespace to determine if it is truly empty"""
+    with open(file_path, 'r') as file:
+        for line in file:
+            stripped_line = line.strip()
+            if stripped_line and not stripped_line.startswith('#'):
+                return False
+    return True
+
+
 def parse_config(config_file: Optional[str], logger: logging.Logger) -> Config:
     """ Config-Parser for AttackMate
 
@@ -88,7 +98,7 @@ def parse_config(config_file: Optional[str], logger: logging.Logger) -> Config:
             for file in default_cfg_path:
                 cfg = None
                 try:
-                    if os.path.getsize(file) == 0:
+                    if os.path.getsize(file) == 0 or is_effectively_empty(file):
                         continue
                     cfg = load_configfile(file)
                 except OSError:
@@ -99,7 +109,7 @@ def parse_config(config_file: Optional[str], logger: logging.Logger) -> Config:
             logger.debug('No config-file found or the default attackmate.yml was empty. Using default-config')
             return Config()
         else:
-            if os.path.getsize(config_file) == 0:
+            if os.path.getsize(config_file) == 0 or is_effectively_empty(config_file):
                 logger.debug(f'Config file {config_file} is empty. Using default config.')
                 return Config()
             logger.debug(f'Config file {config_file} loaded')

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -56,7 +56,7 @@ def initialize_logger(debug: bool):
 def load_configfile(config_file: str) -> Config:
     with open(config_file) as f:
         config = yaml.safe_load(f)
-        return Config.parse_obj(config)
+        return Config.model_validate(config)
 
 
 def parse_config(config_file: Optional[str], logger: logging.Logger) -> Config:
@@ -131,7 +131,7 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     try:
         with open(playbook_file) as f:
             pb_yaml = yaml.safe_load(f)
-            playbook_object = Playbook.parse_obj(pb_yaml)
+            playbook_object = Playbook.model_validate(pb_yaml)
             return playbook_object
     except OSError:
         logger.error(f'Error: Could not open playbook file {playbook_file}')

--- a/src/attackmate/executors/common/setvarexecutor.py
+++ b/src/attackmate/executors/common/setvarexecutor.py
@@ -28,7 +28,7 @@ class SetVarExecutor(BaseExecutor):
             return cmd
 
     def log_command(self, command: SetVarCommand):
-        self.logger.warn(f"Setting Variable: '{command.variable}'")
+        self.logger.warning(f"Setting Variable: '{command.variable}'")
 
     def _exec_cmd(self, command: SetVarCommand) -> Result:
         self.setoutuptvars = False
@@ -37,7 +37,7 @@ class SetVarExecutor(BaseExecutor):
             try:
                 content = self.encode(command.encoder, command.cmd)
             except Exception as e:
-                self.logger.warn(f'Encoding failed. Fallback to plain: {e}')
+                self.logger.warning(f'Encoding failed. Fallback to plain: {e}')
         self.varstore.set_variable(command.variable, content)
 
         return Result('', 0)

--- a/src/attackmate/executors/features/looper.py
+++ b/src/attackmate/executors/features/looper.py
@@ -28,7 +28,7 @@ class Looper:
         if command.loop_if is not None:
             m = re.search(command.loop_if, result.stdout, re.MULTILINE)
             if m is not None:
-                self.logger.warn(
+                self.logger.warning(
                         f'Re-run command because loop_if matches: {m.group(0)}'
                         )
                 if self.run_count < CmdVars.variable_to_int('loop_count', command.loop_count):
@@ -45,7 +45,7 @@ class Looper:
         if command.loop_if_not is not None:
             m = re.search(command.loop_if_not, result.stdout, re.MULTILINE)
             if m is None:
-                self.logger.warn(
+                self.logger.warning(
                         'Re-run command because loop_if_not does not match'
                         )
                 if self.run_count < CmdVars.variable_to_int('loop_count', command.loop_count):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,6 @@
+# Install the local package in editable mode
+-e .. .
+
+# Other dependencies
 pytest
 pytest-mock

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,7 @@
 # Install the local package in editable mode
--e .. .
+# comment out the following line if you only want to run the tests locally
+#-e .. .
 
-# Other dependencies
+# Dependencies for tests
 pytest
 pytest-mock

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,2 @@
-# Install the local package in editable mode
-# comment out the following line if you only want to run the tests locally
-#-e .. .
-
-# Dependencies for tests
 pytest
 pytest-mock

--- a/test/units/test_configfiles.py
+++ b/test/units/test_configfiles.py
@@ -30,6 +30,24 @@ def mock_config_class(mock_config):
     return Config.model_validate(mock_config)
 
 
+def mock_file_open(file_dict):
+    """
+    Helper function to mock open for specific files.
+    Takes a dictionary of file_path: file_content and returns a mock_open object
+    that returns the corresponding file_content when the file_path is opened.
+    """
+    mock_open_instance = mock_open()
+    handle_dict = {file: mock_open(read_data=content).return_value for file, content in file_dict.items()}
+
+    def side_effect(file, *args, **kwargs):
+        if file in handle_dict:
+            return handle_dict[file]
+        raise FileNotFoundError(f"No such file or directory: '{file}'")
+
+    mock_open_instance.side_effect = side_effect
+    return mock_open_instance
+
+
 @patch("os.path.getsize")
 @patch("builtins.open", new_callable=mock_open, read_data="key1: value1\nkey2: value2")
 @patch("attackmate.schemas.config.Config")
@@ -91,3 +109,101 @@ def test_parse_config_yaml_parser_error(mock_open, mock_getsize, mock_logger):
         parse_config('/path/to/invalid/config.yml', mock_logger)
 
     mock_logger.error.assert_called_once()
+
+
+@patch("os.path.getsize")
+@patch("builtins.open", new_callable=mock_open, read_data="###\n###\n")
+@patch("attackmate.schemas.config.Config")
+def test_parse_config_only_comments(mock_config, mock_open, mock_getsize, mock_logger):
+    mock_getsize.return_value = 10
+    mock_config.return_value = Config()
+    cfg = parse_config('/path/to/comment_only/config.yml', mock_logger)
+
+    assert cfg == Config()
+    mock_logger.debug.assert_any_call(
+        'Config file /path/to/comment_only/config.yml is empty. Using default config.')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open", new_callable=mock_open)
+def test_parse_config_no_file_all_defaults_empty(mock_open, mock_getsize, mock_logger):
+    mock_getsize.side_effect = [0, 0, 0]  # simulate all default config files being empty
+    cfg = parse_config(None, mock_logger)
+
+    assert isinstance(cfg, Config)
+    mock_logger.debug.assert_any_call(
+        'No config-file found or the default attackmate.yml was empty. Using default-config')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open")
+@patch("attackmate.schemas.config.Config")
+def test_parse_config_one_default_empty_others_comments(mock_config, mock_open, mock_logger):
+    # simulate the first default config file being empty, and the other two containing comments
+    mock_open.side_effect = [
+        mock_open(read_data="").return_value,
+        mock_open(read_data="###\n###\n").return_value,
+        mock_open(read_data="###").return_value
+    ]
+    cfg = parse_config(None, mock_logger)
+
+    assert cfg == Config()
+    mock_logger.debug.assert_any_call(
+        'No config-file found or the default attackmate.yml was empty. Using default-config')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open")
+@patch("os.environ", {"HOME": "/home/user"})
+def test_parse_config_first_default_has_values(mock_open, mock_getsize, mock_logger):
+    valid_config_data = "key1: value1\nkey2: value2"
+    file_data = {
+        '.attackmate.yml': valid_config_data,
+        '/home/user/.config/attackmate.yml': "",
+        '/etc/attackmate.yml': ""
+    }
+    mock_getsize.side_effect = lambda path: 10 if path == '.attackmate.yml' else 0
+    mock_open_instance = mock_file_open(file_data)
+    mock_open.side_effect = mock_open_instance.side_effect
+    cfg = parse_config(None, mock_logger)
+
+    assert isinstance(cfg, Config)
+    mock_logger.debug.assert_any_call('Config file .attackmate.yml loaded')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open")
+@patch("os.environ", {"HOME": "/home/user"})
+def test_parse_config_middle_default_has_values(mock_open, mock_getsize, mock_logger):
+    valid_config_data = "key1: value1\nkey2: value2"
+    file_data = {
+        '.attackmate.yml': "",
+        '/home/user/.config/attackmate.yml': valid_config_data,
+        '/etc/attackmate.yml': ""
+    }
+    mock_getsize.side_effect = lambda path: 10 if path == '/home/user/.config/attackmate.yml' else 0
+    mock_open_instance = mock_file_open(file_data)
+    mock_open.side_effect = mock_open_instance.side_effect
+    cfg = parse_config(None, mock_logger)
+
+    assert isinstance(cfg, Config)
+    mock_logger.debug.assert_any_call('Config file /home/user/.config/attackmate.yml loaded')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open")
+@patch("os.environ", {"HOME": "/home/user"})
+def test_parse_config_last_default_has_values(mock_open, mock_getsize, mock_logger):
+    valid_config_data = "key1: value1\nkey2: value2"
+    file_data = {
+        '.attackmate.yml': "",
+        '/home/user/.config/attackmate.yml': "",
+        '/etc/attackmate.yml': valid_config_data
+    }
+    mock_getsize.side_effect = lambda path: 0 if path != '/etc/attackmate.yml' else 10
+    mock_open_instance = mock_file_open(file_data)
+    mock_open.side_effect = mock_open_instance.side_effect
+    cfg = parse_config(None, mock_logger)
+
+    assert isinstance(cfg, Config)
+    mock_logger.debug.assert_any_call('Config file /etc/attackmate.yml loaded')

--- a/test/units/test_configfiles.py
+++ b/test/units/test_configfiles.py
@@ -1,0 +1,93 @@
+import yaml
+import pytest
+import logging
+from unittest.mock import patch, mock_open, MagicMock
+from attackmate.__main__ import parse_config
+from attackmate.schemas.config import Config
+
+
+@pytest.fixture
+def mock_logger():
+    logger = MagicMock(spec=logging.Logger)
+    return logger
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "key1": "value1",
+        "key2": "value2"
+    }
+
+
+@pytest.fixture
+def config_content(mock_config):
+    return yaml.dump(mock_config)
+
+
+@pytest.fixture
+def mock_config_class(mock_config):
+    return Config.parse_obj(mock_config)
+
+
+@patch("os.path.getsize")
+@patch("builtins.open", new_callable=mock_open, read_data="key1: value1\nkey2: value2")
+@patch("attackmate.schemas.config.Config")
+def test_parse_config_no_file(mock_config, mock_open, mock_getsize, mock_logger, mock_config_class):
+    mock_getsize.return_value = 10
+    mock_config.parse_obj.return_value = mock_config_class
+
+    cfg = parse_config(None, mock_logger)
+
+    assert cfg == mock_config_class
+    mock_logger.debug.assert_any_call('Config file .attackmate.yml loaded')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open", new_callable=mock_open, read_data="key1: value1\nkey2: value2")
+@patch("attackmate.schemas.config.Config")
+def test_parse_config_specified_file(mock_config, mock_open, mock_getsize, mock_logger, mock_config_class):
+    config_file = '/path/to/config.yml'
+    mock_getsize.return_value = 10
+    mock_config.parse_obj.return_value = mock_config_class
+
+    cfg = parse_config(config_file, mock_logger)
+
+    assert cfg == mock_config_class
+    mock_logger.debug.assert_any_call(f'Config file {config_file} loaded')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open", new_callable=mock_open)
+def test_parse_config_file_not_found(mock_getsize, mock_open, mock_logger):
+    mock_getsize.side_effect = OSError
+
+    with pytest.raises(SystemExit):
+        parse_config('/path/to/nonexistent/config.yml', mock_logger)
+
+    mock_logger.error.assert_any_call('Error: Could not open file /path/to/nonexistent/config.yml')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open", new_callable=mock_open)
+@patch("attackmate.schemas.config.Config")
+def test_parse_config_empty_file(mock_config, mock_open, mock_getsize, mock_logger):
+    mock_getsize.return_value = 0
+    mock_config.return_value = Config()
+
+    cfg = parse_config('/path/to/empty/config.yml', mock_logger)
+
+    assert cfg == Config()
+    mock_logger.debug.assert_any_call('Config file /path/to/empty/config.yml is empty. Using default config.')
+
+
+@patch("os.path.getsize")
+@patch("builtins.open", new_callable=mock_open)
+def test_parse_config_yaml_parser_error(mock_open, mock_getsize, mock_logger):
+    mock_getsize.return_value = 10
+    mock_open.side_effect = yaml.parser.ParserError("Error parsing YAML")
+
+    with pytest.raises(SystemExit):
+        parse_config('/path/to/invalid/config.yml', mock_logger)
+
+    mock_logger.error.assert_called_once()

--- a/test/units/test_configfiles.py
+++ b/test/units/test_configfiles.py
@@ -27,7 +27,7 @@ def config_content(mock_config):
 
 @pytest.fixture
 def mock_config_class(mock_config):
-    return Config.parse_obj(mock_config)
+    return Config.model_validate(mock_config)
 
 
 @patch("os.path.getsize")
@@ -35,7 +35,7 @@ def mock_config_class(mock_config):
 @patch("attackmate.schemas.config.Config")
 def test_parse_config_no_file(mock_config, mock_open, mock_getsize, mock_logger, mock_config_class):
     mock_getsize.return_value = 10
-    mock_config.parse_obj.return_value = mock_config_class
+    mock_config.model_validate.return_value = mock_config_class
 
     cfg = parse_config(None, mock_logger)
 
@@ -49,7 +49,7 @@ def test_parse_config_no_file(mock_config, mock_open, mock_getsize, mock_logger,
 def test_parse_config_specified_file(mock_config, mock_open, mock_getsize, mock_logger, mock_config_class):
     config_file = '/path/to/config.yml'
     mock_getsize.return_value = 10
-    mock_config.parse_obj.return_value = mock_config_class
+    mock_config.model_validate.return_value = mock_config_class
 
     cfg = parse_config(config_file, mock_logger)
 


### PR DESCRIPTION
This PR fixes Issue #73.

In details, it includes the following:
- If there is any of the default `attackmate.yml` file existing, but it is empty, the default config variables are loaded.
- If there is a file provided with the `--config` flag, but it's empty, the default config variables are loaded.
- There are unit tests added to test the `parse_config` function in `__main__.py`.
- Deprecated method warnings of the tests were fixed: the `parse_obj` function uses `model_validate`; and the `warn` function uses `warning` under the hood, so these are just beauty fixes.