### PR TITLE
raise exception for missing hostname

### DIFF
--- a/src/attackmate/executors/ssh/sshexecutor.py
+++ b/src/attackmate/executors/ssh/sshexecutor.py
@@ -106,6 +106,9 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
         if self.jmp_hostname is not None:
             jmp_sock = self.connect_jmphost(command)
 
+        if self.hostname is None:
+            raise ExecException('No hostname set for SSH-Connection')
+
         kwargs = dict(
             hostname=self.hostname,
             port=self.port,
@@ -149,6 +152,8 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
                     output = stdout.read().decode('utf-8', 'ignore')
                     error = stderr.read().decode('utf-8', 'ignore')
         except ValueError as e:
+            raise ExecException(e)
+        except AttributeError as e:
             raise ExecException(e)
         except BadHostKeyException as e:
             raise ExecException(e)


### PR DESCRIPTION
This PR fixes issue #80 
- SSHExecutor raises ExecException (handled downstream by BaseExecutor) before a ssh connection is attempted without specifying a hostname