### PR TITLE
Bug father path

### DIFF
--- a/src/attackmate/executors/father/fatherexecutor.py
+++ b/src/attackmate/executors/father/fatherexecutor.py
@@ -64,6 +64,7 @@ class FatherExecutor(BaseExecutor):
             return Result('Compiling Father only works for Linux!', 1)
 
         data_path = os.path.join(Path(__file__).parents[2], 'data', 'Father.tar.gz')
+        
         if command.local_path:
             father_path = command.local_path
         else:

--- a/src/attackmate/executors/father/fatherexecutor.py
+++ b/src/attackmate/executors/father/fatherexecutor.py
@@ -9,6 +9,7 @@ import subprocess
 import tarfile
 import os
 import tempfile
+from pathlib import Path
 from string import Template
 from typing import Any
 from attackmate.executors.baseexecutor import BaseExecutor
@@ -62,7 +63,7 @@ class FatherExecutor(BaseExecutor):
         if platform.system() != 'Linux':
             return Result('Compiling Father only works for Linux!', 1)
 
-        data_path = os.path.join(os.path.dirname(__file__), 'data', 'Father.tar.gz')
+        data_path = os.path.join(Path(__file__).parents[2], 'data', 'Father.tar.gz')
         if command.local_path:
             father_path = command.local_path
         else:


### PR DESCRIPTION
fixes path to father.tar gz 
solves issue #72 

`/usr/local/share/attackmate/venv/lib/python3.12/site-packages/attackmate/data/Father.tar.gz`

instead of

`/usr/local/share/attackmate/venv/lib/python3.12/site-packages/attackmate/executors/father/data/Father.tar.gz`