### PR TITLE
bugfix regex modes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '.*.log'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -15,18 +15,18 @@ repos:
     -   id: check-ast
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.10.1
     hooks:
     -   id: mypy
         additional_dependencies: [pydantic, types-PyYAML, types-requests, types-paramiko, types-tabulate]
 
 -   repo: https://github.com/pycqa/flake8
-    rev: '6.1.0'  # pick a git hash / tag to point to
+    rev: '7.1.0'  # pick a git hash / tag to point to
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: ''
+    rev: 'v2.0.4'
     hooks:
     - id: autopep8
       args: [--max-line-length=110, --diff]

--- a/docs/source/playbook/commands/regex.rst
+++ b/docs/source/playbook/commands/regex.rst
@@ -63,12 +63,12 @@ By using the mode "split", strings that are seperated by whitespaces can be toke
 
         - type: regex
           cmd: hello
-          mode: sub
           replace: whaat
+          mode: sub
           input: FOO
           output:
-            BAR: $MATCH
-      
+            BAR: $MATCH_0
+
         - type: debug
           cmd: $BAR
 
@@ -86,8 +86,8 @@ By using the mode "split", strings that are seperated by whitespaces can be toke
    must be a list of key-value pairs("variable-name": "$MATCH"). The matches
    of the regular expressions are stored in temporary variables $MATCH. If the
    match is stored in a list or in a list of tuples the variablename will be
-   numbered by the index. For examle: "$MATCH_0_0" for the first element in the
-   first occurance.
+   numbered by the index. For example: "$MATCH_0_0" for the first element in the
+   first occurance. The first match (even if there is only one) is indexed MATCH_0.
    If the regex-command does not match, no output variable will be set!
 
    .. note::

--- a/examples/regex.yml
+++ b/examples/regex.yml
@@ -51,6 +51,7 @@ commands:
     # MODE SUB
   - type: regex
     input: INPUT
+    replace: SUBSTITUTION
     cmd: tcp
     mode: sub
     output:

--- a/examples/regex.yml
+++ b/examples/regex.yml
@@ -1,0 +1,64 @@
+# Author: Thorina Boenke
+# Description:
+#     This playbook demonstrates different modes of the regex command:
+#     1. Sets a variable as input string for the regex commands
+#     2. runs different regex commands
+#     3. displays the Outputvariable of the regex command with debug sommand
+#
+
+commands:
+
+  - type: setvar
+    variable: $INPUT
+    cmd: "6667/tcp open  irc UnrealIRCd"
+
+  # MODE FINDALL
+  - type: regex
+    input: INPUT
+    cmd: "666"
+    mode: findall
+    output:
+        # {'MATCH_0': '6', 'MATCH_1': '6', 'MATCH_2': '6'}
+        FIRST_MATCH: "$MATCH_0"
+
+  - type: debug
+    cmd: "Match: $FIRST_MATCH"
+
+  # MODE SPLIT
+  - type: regex
+    input: INPUT
+    cmd: "\ +"
+    mode: split
+    output:
+        # {'MATCH_0': '6667/tcp', 'MATCH_1': 'open', 'MATCH_2': 'irc', 'MATCH_3': 'UnrealIRCd\n'}
+        UNREALPORT: "$MATCH_0"
+
+  - type: debug
+    cmd: "Port: $UNREALPORT"
+
+  # MODE SEARCH
+  - type: regex
+    input: INPUT
+    cmd: tcp
+    mode: search
+    output:
+        # {'MATCH_0': 'tcp'}
+        SEARCH: "$MATCH_0"
+
+  - type: debug
+    cmd: "Search Result: $SEARCH"
+
+    # MODE SUB
+  - type: regex
+    input: INPUT
+    cmd: tcp
+    mode: sub
+    output:
+        # {'MATCH_0': '6667/hello open  irc UnrealIRCd'}
+        SUBSTITUTED: "$MATCH_0"
+
+  - type: debug
+    cmd: "Result string: $SUBSTITUTED"
+
+  
+

--- a/examples/regex.yml
+++ b/examples/regex.yml
@@ -18,7 +18,7 @@ commands:
     cmd: "666"
     mode: findall
     output:
-        # {'MATCH_0': '6', 'MATCH_1': '6', 'MATCH_2': '6'}
+        # {'MATCH_0': '666'}
         FIRST_MATCH: "$MATCH_0"
 
   - type: debug
@@ -55,7 +55,7 @@ commands:
     cmd: tcp
     mode: sub
     output:
-        # {'MATCH_0': '6667/hello open  irc UnrealIRCd'}
+        # {'MATCH_0': '6667/SUBSTITUTION open  irc UnrealIRCd'}
         SUBSTITUTED: "$MATCH_0"
 
   - type: debug

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -149,7 +149,7 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
         exit(1)
     except ValidationError:
         logger.error(f'A Validation error occured when parsing playbook file {playbook_file}')
-        logger.error(traceback.format_exc())  
+        logger.error(traceback.format_exc())
         exit(1)
 
 

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -151,7 +151,7 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
         logger.error(f'A Validation error occured when parsing playbook file {playbook_file}')
         logger.error(traceback.format_exc())  
         exit(1)
-    
+
 
 def parse_args():
     description = 'AttackMate is an attack orchestration tool' \

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -10,8 +10,10 @@ import sys
 import argparse
 import yaml
 import logging
+import traceback
 from typing import Optional
 from colorlog import ColoredFormatter
+from pydantic import ValidationError
 from .attackmate import AttackMate
 from attackmate.schemas.config import Config
 from attackmate.schemas.playbook import Playbook
@@ -145,7 +147,11 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     except OSError:
         logger.error(f'Error: Could not open playbook file {playbook_file}')
         exit(1)
-
+    except ValidationError:
+        logger.error(f'A Validation error occured when parsing playbook file {playbook_file}')
+        logger.error(traceback.format_exc())  
+        exit(1)
+    
 
 def parse_args():
     description = 'AttackMate is an attack orchestration tool' \

--- a/src/attackmate/executors/common/regexexecutor.py
+++ b/src/attackmate/executors/common/regexexecutor.py
@@ -14,32 +14,31 @@ import re
 
 
 class RegExExecutor(BaseExecutor):
+    
+    def log_command(self, command: RegExCommand):
+        self.logger.warn(f"RegEx: '{command.cmd}', Mode: '{command.mode}'")
 
+    
     def forge_variables(self, data, variable_name='MATCH'):
         result = {}
         if data is None:
             return None
         if isinstance(data, str):
-            result[variable_name] = data
-        elif isinstance(data, list) or isinstance(data, tuple):
-            i = 0
-            for item in data:
+            result[f'{variable_name}_0'] = data
+        elif isinstance(data, (list, tuple)):
+            for i, item in enumerate(data):
                 tmpvar = f'{variable_name}_{str(i)}'
                 if isinstance(item, str):
                     result[tmpvar] = item
-                elif isinstance(item, list) or isinstance(item, tuple):
-                    j = 0
-                    for level2 in item:
+                elif isinstance(item, (list, tuple)):
+                    for j, level2 in enumerate(item):
                         tmpvar2 = f'{tmpvar}_{str(j)}'
                         if isinstance(level2, str):
                             result[tmpvar2] = level2
-                        j += 1
-                i += 1
+
         return result
 
-    def log_command(self, command: RegExCommand):
-        self.logger.warn(f"RegEx: '{command.cmd}'")
-
+    
     def register_outputvars(self, outputvars: dict, matches):
         if not matches:
             self.logger.debug('no match!')
@@ -49,28 +48,28 @@ class RegExExecutor(BaseExecutor):
             temp = Template(v)
             self.varstore.set_variable(k, temp.safe_substitute(matches))
 
+    def forge_and_register_variables(self, output: dict, data) -> dict:
+        matches = self.forge_variables(data)
+        self.logger.debug(matches)
+        self.register_outputvars(output, matches)
+        return
+
     def _exec_cmd(self, command: RegExCommand) -> Result:
         self.setoutuptvars = False
         if command.mode == 'findall':
             m = re.findall(command.cmd, self.varstore.get_variable(command.input))
-            matches = self.forge_variables(m)
-            self.logger.debug(matches)
-            self.register_outputvars(command.output, matches)
+            self.forge_and_register_variables(command.output, m)
         if command.mode == 'split':
             m = re.split(command.cmd, self.varstore.get_variable(command.input))
-            matches = self.forge_variables(m)
-            self.logger.debug(matches)
-            self.register_outputvars(command.output, matches)
+            self.forge_and_register_variables(command.output, m)
         if command.mode == 'search':
+            # search() module will only return the first occurrence that matches the specified pattern.
             m3 = re.search(command.cmd, self.varstore.get_variable(command.input))
             if m3 is not None and isinstance(m3, Match):
-                matches = self.forge_variables(m3.groups())
-                self.logger.debug(matches)
-                self.register_outputvars(command.output, matches)
+                self.forge_and_register_variables(command.output, m3.group())
         if command.mode == 'sub':
             if command.replace:
                 replaced = re.sub(command.cmd, command.replace, self.varstore.get_variable(command.input))
-                matches = self.forge_variables(replaced)
-                self.register_outputvars(command.output, matches)
+                self.forge_and_register_variables(command.output, replaced)
 
         return Result('', 0)

--- a/src/attackmate/executors/common/regexexecutor.py
+++ b/src/attackmate/executors/common/regexexecutor.py
@@ -14,11 +14,10 @@ import re
 
 
 class RegExExecutor(BaseExecutor):
-    
+
     def log_command(self, command: RegExCommand):
         self.logger.warn(f"RegEx: '{command.cmd}', Mode: '{command.mode}'")
 
-    
     def forge_variables(self, data, variable_name='MATCH'):
         result = {}
         if data is None:
@@ -38,7 +37,6 @@ class RegExExecutor(BaseExecutor):
 
         return result
 
-    
     def register_outputvars(self, outputvars: dict, matches):
         if not matches:
             self.logger.debug('no match!')
@@ -48,7 +46,7 @@ class RegExExecutor(BaseExecutor):
             temp = Template(v)
             self.varstore.set_variable(k, temp.safe_substitute(matches))
 
-    def forge_and_register_variables(self, output: dict, data) -> dict:
+    def forge_and_register_variables(self, output: dict, data):
         matches = self.forge_variables(data)
         self.logger.debug(matches)
         self.register_outputvars(output, matches)

--- a/src/attackmate/executors/father/fatherexecutor.py
+++ b/src/attackmate/executors/father/fatherexecutor.py
@@ -64,7 +64,7 @@ class FatherExecutor(BaseExecutor):
             return Result('Compiling Father only works for Linux!', 1)
 
         data_path = os.path.join(Path(__file__).parents[2], 'data', 'Father.tar.gz')
-        
+
         if command.local_path:
             father_path = command.local_path
         else:

--- a/src/attackmate/executors/features/cmdvars.py
+++ b/src/attackmate/executors/features/cmdvars.py
@@ -70,6 +70,8 @@ class CmdVars:
 
     @staticmethod
     def variable_to_bool(variablename: str, value: str) -> bool:
-        if str(value).lower() in ("yes", "y", "true",  "t", "1"): return True
-        if str(value).lower() in ("no",  "n", "false", "f", "0", "0.0", "", "none", "[]", "{}"): return False
+        if str(value).lower() in ('yes', 'y', 'true',  't', '1'):
+            return True
+        if str(value).lower() in ('no',  'n', 'false', 'f', '0', '0.0', '', 'none', '[]', '{}'):
+            return False
         raise ExecException(f'Invalid value for boolean conversion of {variablename}: {value}')

--- a/src/attackmate/executors/shell/shellexecutor.py
+++ b/src/attackmate/executors/shell/shellexecutor.py
@@ -9,8 +9,6 @@ import os
 import subprocess
 from subprocess import TimeoutExpired
 from datetime import datetime
-from queue import Queue, Empty
-from threading import Thread
 from attackmate.execexception import ExecException
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.result import Result
@@ -72,9 +70,8 @@ class ShellExecutor(BaseExecutor):
         output += error
         return output.decode()
 
-    def popen_interactive(self, proc: subprocess.Popen, cmd: bytes, timeout: int=5, read: bool=True) -> str:
+    def popen_interactive(self, proc: subprocess.Popen, cmd: bytes, timeout: int = 5, read: bool = True) -> str:
         self.logger.debug("Running interactive command")
-        q = Queue()
 
         self.logger.debug(f"Sending command: {cmd}")
         if proc.stdin:
@@ -84,14 +81,13 @@ class ShellExecutor(BaseExecutor):
         outline = b''
         if read:
             begin = datetime.now()
-            while (datetime.now() - begin ).total_seconds() < timeout:
+            while (datetime.now() - begin).total_seconds() < timeout:
                 tmp = self.non_block_read(proc.stdout)
                 if tmp:
                     outline += tmp
                     begin = datetime.now() # reset timer when data comes
 
         return outline.decode()
-
 
     def _exec_cmd(self, command: ShellCommand) -> Result:
         try:
@@ -100,7 +96,7 @@ class ShellExecutor(BaseExecutor):
             raise ExecException(e)
 
         cmd = command.cmd.encode('utf-8')
-        timeout = CmdVars.variable_to_int("timeout", command.command_timeout )
+        timeout = CmdVars.variable_to_int("timeout", command.command_timeout)
         output = ''
 
         if command.interactive:
@@ -110,6 +106,5 @@ class ShellExecutor(BaseExecutor):
         else:
             output = self.popen_noninteractive(proc, cmd)
             self.popen_close(proc)
-
 
         return Result(output, 0)

--- a/src/attackmate/executors/shell/shellexecutor.py
+++ b/src/attackmate/executors/shell/shellexecutor.py
@@ -33,7 +33,10 @@ class ShellExecutor(BaseExecutor):
         if command.session:
             return self.session_store.get_handle_by_session(command.session)
 
-        proc = subprocess.Popen([command.command_shell], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen([command.command_shell],
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
 
         if command.creates_session:
             self.session_store.set_session(command.creates_session, proc, command.cmd)
@@ -41,7 +44,7 @@ class ShellExecutor(BaseExecutor):
         return proc
 
     def popen_close(self, proc):
-        self.logger.debug("Closing popen process")
+        self.logger.debug('Closing popen process')
         proc.terminate()
         proc.wait(timeout=10)
 
@@ -53,27 +56,31 @@ class ShellExecutor(BaseExecutor):
             fl = fcntl.fcntl(fd, fcntl.F_GETFL)
             fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
         except ImportError:
-            raise ExecException("The 'fcntl' module is not available. This functionality requires a Unix-like operating system.")
+            raise ExecException("The 'fcntl' module is not available. This module requires a Unix-like OS.")
         try:
             return stdout.read()
-        except:
-            return b""
+        except Exception:
+            return b''
 
     def popen_noninteractive(self, proc: subprocess.Popen, cmd: bytes, timeout=None) -> str:
-        self.logger.debug("Running non interactive command")
+        self.logger.debug('Running non interactive command')
         try:
             output, error = proc.communicate(cmd, timeout=timeout)
         except TimeoutExpired:
-            self.logger.info("Timeout of noninteractive shell command expired")
+            self.logger.info('Timeout of noninteractive shell command expired')
             proc.kill()
             output, error = proc.communicate()
         output += error
         return output.decode()
 
-    def popen_interactive(self, proc: subprocess.Popen, cmd: bytes, timeout: int = 5, read: bool = True) -> str:
-        self.logger.debug("Running interactive command")
+    def popen_interactive(self,
+                          proc: subprocess.Popen,
+                          cmd: bytes,
+                          timeout: int = 5,
+                          read: bool = True) -> str:
+        self.logger.debug('Running interactive command')
 
-        self.logger.debug(f"Sending command: {cmd}")
+        self.logger.debug(f"Sending command: {cmd.decode('utf-8')}")
         if proc.stdin:
             proc.stdin.write(cmd)
             proc.stdin.flush()
@@ -85,7 +92,7 @@ class ShellExecutor(BaseExecutor):
                 tmp = self.non_block_read(proc.stdout)
                 if tmp:
                     outline += tmp
-                    begin = datetime.now() # reset timer when data comes
+                    begin = datetime.now()  # reset timer when data comes
 
         return outline.decode()
 
@@ -96,7 +103,7 @@ class ShellExecutor(BaseExecutor):
             raise ExecException(e)
 
         cmd = command.cmd.encode('utf-8')
-        timeout = CmdVars.variable_to_int("timeout", command.command_timeout)
+        timeout = CmdVars.variable_to_int('timeout', command.command_timeout)
         output = ''
 
         if command.interactive:

--- a/src/attackmate/schemas/regex.py
+++ b/src/attackmate/schemas/regex.py
@@ -2,21 +2,27 @@ from typing import Literal, Optional
 from pydantic import ValidationInfo, field_validator
 from .base import BaseCommand
 from pprint import pprint
+import logging
 
+logger = logging.getLogger('playbook')
 
 class RegExCommand(BaseCommand):
+    
     @field_validator('mode')
     @classmethod
     def sub_needs_replace(cls, v, info: ValidationInfo) -> str:
-        if 'replace' in info.data and info.data['replace']:
-            return v
-        else:
+
+        if v == 'sub' and not info.data.get('replace'):
             print(info.data)
             pprint(info)
-            raise ValueError('Regex: sub needs the replace-setting!')
+            logger.error('Error parsing playbook. regex command mode: sub must be preceded by the replace setting!')
+            raise ValueError('Regex sub mode needs replace-setting!')
+        
+        return v
+            
 
     type: Literal['regex']
-    # replace is a dependency for mode, therefor it must be place BEFORE mode!
+    # replace is a dependency for mode, therefore it must be placed BEFORE mode!
     replace: Optional[str] = None
     mode: Literal['search', 'split', 'findall', 'sub'] = 'findall'
     input: str = 'RESULT_STDOUT'

--- a/src/attackmate/schemas/regex.py
+++ b/src/attackmate/schemas/regex.py
@@ -8,7 +8,7 @@ logger = logging.getLogger('playbook')
 
 
 class RegExCommand(BaseCommand):
- 
+
     @field_validator('mode')
     @classmethod
     def sub_needs_replace(cls, v, info: ValidationInfo) -> str:
@@ -16,7 +16,7 @@ class RegExCommand(BaseCommand):
         if v == 'sub' and not info.data.get('replace'):
             print(info.data)
             pprint(info)
-            logger.error('Error parsing playbook. regex command mode: sub must be preceded by the replace setting!')
+            logger.error('Error parsing playbook. command mode: sub must be preceded by replace setting!')
             raise ValueError('Regex sub mode needs replace-setting!')
 
         return v

--- a/src/attackmate/schemas/regex.py
+++ b/src/attackmate/schemas/regex.py
@@ -6,8 +6,9 @@ import logging
 
 logger = logging.getLogger('playbook')
 
+
 class RegExCommand(BaseCommand):
-    
+ 
     @field_validator('mode')
     @classmethod
     def sub_needs_replace(cls, v, info: ValidationInfo) -> str:
@@ -17,9 +18,8 @@ class RegExCommand(BaseCommand):
             pprint(info)
             logger.error('Error parsing playbook. regex command mode: sub must be preceded by the replace setting!')
             raise ValueError('Regex sub mode needs replace-setting!')
-        
+
         return v
-            
 
     type: Literal['regex']
     # replace is a dependency for mode, therefore it must be placed BEFORE mode!

--- a/src/attackmate/schemas/regex.py
+++ b/src/attackmate/schemas/regex.py
@@ -1,10 +1,6 @@
 from typing import Literal, Optional
 from pydantic import ValidationInfo, field_validator
 from .base import BaseCommand
-from pprint import pprint
-import logging
-
-logger = logging.getLogger('playbook')
 
 
 class RegExCommand(BaseCommand):
@@ -14,10 +10,9 @@ class RegExCommand(BaseCommand):
     def sub_needs_replace(cls, v, info: ValidationInfo) -> str:
 
         if v == 'sub' and not info.data.get('replace'):
-            print(info.data)
-            pprint(info)
-            logger.error('Error parsing playbook. command mode: sub must be preceded by replace setting!')
-            raise ValueError('Regex sub mode needs replace-setting!')
+            raise ValueError(
+                'Error parsing playbook. regex command mode: sub must be preceded by replace setting!'
+            )
 
         return v
 

--- a/src/attackmate/variablestore.py
+++ b/src/attackmate/variablestore.py
@@ -27,7 +27,7 @@ class VariableStore:
             try:
                 return temp.substitute(self.variables)
             except KeyError:
-                return ""
+                return ''
         else:
             return temp.safe_substitute(self.variables)
 

--- a/test/units/test_configfiles.py
+++ b/test/units/test_configfiles.py
@@ -15,8 +15,8 @@ def mock_logger():
 @pytest.fixture
 def mock_config():
     return {
-        "key1": "value1",
-        "key2": "value2"
+        'key1': 'value1',
+        'key2': 'value2'
     }
 
 
@@ -48,9 +48,9 @@ def mock_file_open(file_dict):
     return mock_open_instance
 
 
-@patch("os.path.getsize")
-@patch("builtins.open", new_callable=mock_open, read_data="key1: value1\nkey2: value2")
-@patch("attackmate.schemas.config.Config")
+@patch('os.path.getsize')
+@patch('builtins.open', new_callable=mock_open, read_data='key1: value1\nkey2: value2')
+@patch('attackmate.schemas.config.Config')
 def test_parse_config_no_file(mock_config, mock_open, mock_getsize, mock_logger, mock_config_class):
     mock_getsize.return_value = 10
     mock_config.model_validate.return_value = mock_config_class
@@ -61,9 +61,9 @@ def test_parse_config_no_file(mock_config, mock_open, mock_getsize, mock_logger,
     mock_logger.debug.assert_any_call('Config file .attackmate.yml loaded')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open", new_callable=mock_open, read_data="key1: value1\nkey2: value2")
-@patch("attackmate.schemas.config.Config")
+@patch('os.path.getsize')
+@patch('builtins.open', new_callable=mock_open, read_data='key1: value1\nkey2: value2')
+@patch('attackmate.schemas.config.Config')
 def test_parse_config_specified_file(mock_config, mock_open, mock_getsize, mock_logger, mock_config_class):
     config_file = '/path/to/config.yml'
     mock_getsize.return_value = 10
@@ -75,8 +75,8 @@ def test_parse_config_specified_file(mock_config, mock_open, mock_getsize, mock_
     mock_logger.debug.assert_any_call(f'Config file {config_file} loaded')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open", new_callable=mock_open)
+@patch('os.path.getsize')
+@patch('builtins.open', new_callable=mock_open)
 def test_parse_config_file_not_found(mock_getsize, mock_open, mock_logger):
     mock_getsize.side_effect = OSError
 
@@ -86,9 +86,9 @@ def test_parse_config_file_not_found(mock_getsize, mock_open, mock_logger):
     mock_logger.error.assert_any_call('Error: Could not open file /path/to/nonexistent/config.yml')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open", new_callable=mock_open)
-@patch("attackmate.schemas.config.Config")
+@patch('os.path.getsize')
+@patch('builtins.open', new_callable=mock_open)
+@patch('attackmate.schemas.config.Config')
 def test_parse_config_empty_file(mock_config, mock_open, mock_getsize, mock_logger):
     mock_getsize.return_value = 0
     mock_config.return_value = Config()
@@ -99,11 +99,11 @@ def test_parse_config_empty_file(mock_config, mock_open, mock_getsize, mock_logg
     mock_logger.debug.assert_any_call('Config file /path/to/empty/config.yml is empty. Using default config.')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open", new_callable=mock_open)
+@patch('os.path.getsize')
+@patch('builtins.open', new_callable=mock_open)
 def test_parse_config_yaml_parser_error(mock_open, mock_getsize, mock_logger):
     mock_getsize.return_value = 10
-    mock_open.side_effect = yaml.parser.ParserError("Error parsing YAML")
+    mock_open.side_effect = yaml.parser.ParserError('Error parsing YAML')
 
     with pytest.raises(SystemExit):
         parse_config('/path/to/invalid/config.yml', mock_logger)
@@ -111,9 +111,9 @@ def test_parse_config_yaml_parser_error(mock_open, mock_getsize, mock_logger):
     mock_logger.error.assert_called_once()
 
 
-@patch("os.path.getsize")
-@patch("builtins.open", new_callable=mock_open, read_data="###\n###\n")
-@patch("attackmate.schemas.config.Config")
+@patch('os.path.getsize')
+@patch('builtins.open', new_callable=mock_open, read_data='###\n###\n')
+@patch('attackmate.schemas.config.Config')
 def test_parse_config_only_comments(mock_config, mock_open, mock_getsize, mock_logger):
     mock_getsize.return_value = 10
     mock_config.return_value = Config()
@@ -124,8 +124,8 @@ def test_parse_config_only_comments(mock_config, mock_open, mock_getsize, mock_l
         'Config file /path/to/comment_only/config.yml is empty. Using default config.')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open", new_callable=mock_open)
+@patch('os.path.getsize')
+@patch('builtins.open', new_callable=mock_open)
 def test_parse_config_no_file_all_defaults_empty(mock_open, mock_getsize, mock_logger):
     mock_getsize.side_effect = [0, 0, 0]  # simulate all default config files being empty
     cfg = parse_config(None, mock_logger)
@@ -135,15 +135,15 @@ def test_parse_config_no_file_all_defaults_empty(mock_open, mock_getsize, mock_l
         'No config-file found or the default attackmate.yml was empty. Using default-config')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open")
-@patch("attackmate.schemas.config.Config")
+@patch('os.path.getsize')
+@patch('builtins.open')
+@patch('attackmate.schemas.config.Config')
 def test_parse_config_one_default_empty_others_comments(mock_config, mock_open, mock_logger):
     # simulate the first default config file being empty, and the other two containing comments
     mock_open.side_effect = [
-        mock_open(read_data="").return_value,
-        mock_open(read_data="###\n###\n").return_value,
-        mock_open(read_data="###").return_value
+        mock_open(read_data='').return_value,
+        mock_open(read_data='###\n###\n').return_value,
+        mock_open(read_data='###').return_value
     ]
     cfg = parse_config(None, mock_logger)
 
@@ -152,15 +152,15 @@ def test_parse_config_one_default_empty_others_comments(mock_config, mock_open, 
         'No config-file found or the default attackmate.yml was empty. Using default-config')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open")
-@patch("os.environ", {"HOME": "/home/user"})
+@patch('os.path.getsize')
+@patch('builtins.open')
+@patch('os.environ', {'HOME': '/home/user'})
 def test_parse_config_first_default_has_values(mock_open, mock_getsize, mock_logger):
-    valid_config_data = "key1: value1\nkey2: value2"
+    valid_config_data = 'key1: value1\nkey2: value2'
     file_data = {
         '.attackmate.yml': valid_config_data,
-        '/home/user/.config/attackmate.yml': "",
-        '/etc/attackmate.yml': ""
+        '/home/user/.config/attackmate.yml': '',
+        '/etc/attackmate.yml': ''
     }
     mock_getsize.side_effect = lambda path: 10 if path == '.attackmate.yml' else 0
     mock_open_instance = mock_file_open(file_data)
@@ -171,15 +171,15 @@ def test_parse_config_first_default_has_values(mock_open, mock_getsize, mock_log
     mock_logger.debug.assert_any_call('Config file .attackmate.yml loaded')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open")
-@patch("os.environ", {"HOME": "/home/user"})
+@patch('os.path.getsize')
+@patch('builtins.open')
+@patch('os.environ', {'HOME': '/home/user'})
 def test_parse_config_middle_default_has_values(mock_open, mock_getsize, mock_logger):
-    valid_config_data = "key1: value1\nkey2: value2"
+    valid_config_data = 'key1: value1\nkey2: value2'
     file_data = {
-        '.attackmate.yml': "",
+        '.attackmate.yml': '',
         '/home/user/.config/attackmate.yml': valid_config_data,
-        '/etc/attackmate.yml': ""
+        '/etc/attackmate.yml': ''
     }
     mock_getsize.side_effect = lambda path: 10 if path == '/home/user/.config/attackmate.yml' else 0
     mock_open_instance = mock_file_open(file_data)
@@ -190,14 +190,14 @@ def test_parse_config_middle_default_has_values(mock_open, mock_getsize, mock_lo
     mock_logger.debug.assert_any_call('Config file /home/user/.config/attackmate.yml loaded')
 
 
-@patch("os.path.getsize")
-@patch("builtins.open")
-@patch("os.environ", {"HOME": "/home/user"})
+@patch('os.path.getsize')
+@patch('builtins.open')
+@patch('os.environ', {'HOME': '/home/user'})
 def test_parse_config_last_default_has_values(mock_open, mock_getsize, mock_logger):
-    valid_config_data = "key1: value1\nkey2: value2"
+    valid_config_data = 'key1: value1\nkey2: value2'
     file_data = {
-        '.attackmate.yml': "",
-        '/home/user/.config/attackmate.yml': "",
+        '.attackmate.yml': '',
+        '/home/user/.config/attackmate.yml': '',
         '/etc/attackmate.yml': valid_config_data
     }
     mock_getsize.side_effect = lambda path: 0 if path != '/etc/attackmate.yml' else 10

--- a/test/units/test_regexcommand.py
+++ b/test/units/test_regexcommand.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import ValidationError
+from attackmate.schemas.regex import RegExCommand
+
+
+class TestRegExCommand:
+    def test_sub_needs_replace_valid(self):
+        # Test when mode is 'sub' and replace is provided
+        command = RegExCommand(type='regex', cmd='test', mode='sub', replace='some_replace', output={})
+        assert command.mode == 'sub'
+        assert command.replace == 'some_replace'
+
+    def test_sub_needs_replace_invalid(self):
+        # Test when mode is 'sub' but replace is not provided
+        with pytest.raises(ValueError, match='Regex sub mode needs replace-setting!'):
+            RegExCommand(type='regex', cmd='test', mode='sub', output={})
+
+    def test_default_values(self):
+        # Test default values for other attributes
+        command = RegExCommand(type='regex', cmd='test', output={})
+        assert command.mode == 'findall'
+        assert command.input == 'RESULT_STDOUT'
+        assert command.replace is None
+        assert command.output == {}
+
+    def test_missing_cmd_argument(self):
+        # Test for missing 'cmd' argument
+        with pytest.raises(ValidationError, match='1 validation error for RegExCommand'):
+            RegExCommand(type='regex', output={})

--- a/test/units/test_regexcommand.py
+++ b/test/units/test_regexcommand.py
@@ -12,7 +12,10 @@ class TestRegExCommand:
 
     def test_sub_needs_replace_invalid(self):
         # Test when mode is 'sub' but replace is not provided
-        with pytest.raises(ValueError, match='Regex sub mode needs replace-setting!'):
+        with pytest.raises(
+            ValueError,
+            match='Error parsing playbook. regex command mode: sub must be preceded by replace setting!',
+        ):
             RegExCommand(type='regex', cmd='test', mode='sub', output={})
 
     def test_default_values(self):

--- a/test/units/test_regexexecutor.py
+++ b/test/units/test_regexexecutor.py
@@ -1,0 +1,155 @@
+from unittest.mock import MagicMock
+from attackmate.variablestore import VariableStore
+from attackmate.processmanager import ProcessManager
+from attackmate.schemas.regex import RegExCommand
+from attackmate.executors.common.regexexecutor import RegExExecutor
+
+
+class TestRegExExecutor:
+    def setup_method(self, method):
+        self.varstore = VariableStore()
+        self.process_manager = ProcessManager()
+        self.executor = RegExExecutor(self.process_manager, self.varstore)
+        self.executor.logger = MagicMock()
+
+    def test_log_command(self):
+        command = RegExCommand(type='regex', cmd='test', mode='findall', output={})
+        self.executor.log_command(command)
+        self.executor.logger.warn.assert_called_once_with("RegEx: 'test', Mode: 'findall'")
+
+    def test_forge_variables(self):
+
+        # Test with None
+        result = self.executor.forge_variables(None)
+        assert result is None
+
+        # Test with string
+        result = self.executor.forge_variables('test')
+        assert result == {'MATCH_0': 'test'}
+
+        # Test with list of strings
+        result = self.executor.forge_variables(['test1', 'test2'])
+        assert result == {'MATCH_0': 'test1', 'MATCH_1': 'test2'}
+
+        # Test with nested list
+        result = self.executor.forge_variables([['test1', 'test2'], ['test3', 'test4']])
+        assert result == {
+            'MATCH_0_0': 'test1',
+            'MATCH_0_1': 'test2',
+            'MATCH_1_0': 'test3',
+            'MATCH_1_1': 'test4',
+        }
+
+    def test_register_outputvars(self):
+        matches = {'MATCH_0': 'test'}
+        outputvars = {'output_var': 'Matched: $MATCH_0'}
+        self.executor.register_outputvars(outputvars, matches)
+        assert self.varstore.get_variable('output_var') == 'Matched: test'
+
+    def test_forge_and_register_variables(self):
+        output = {'output_var': 'Matched: $MATCH_0'}
+        data = 'test'
+        self.executor.forge_and_register_variables(output, data)
+        assert self.varstore.get_variable('output_var') == 'Matched: test'
+
+    def test_exec_cmd_findall(self):
+        # Test mode "findall"
+        self.varstore.set_variable('input_var', 'test1 test2 test3')
+        command = RegExCommand(
+            type='regex',
+            cmd='test\\d',
+            mode='findall',
+            input='input_var',
+            output={'output_var': 'Found: $MATCH_0, $MATCH_1, $MATCH_2'},
+        )
+        self.executor._exec_cmd(command)
+        assert self.varstore.get_variable('output_var') == 'Found: test1, test2, test3'
+
+    def test_exec_cmd_split(self):
+        # Test mode "split"
+        self.varstore.set_variable('input_var', 'test1 test2 test3')
+        command = RegExCommand(
+            type='regex',
+            cmd='\\s',
+            mode='split',
+            input='input_var',
+            output={'output_var': 'First: $MATCH_0, Second: $MATCH_1, Third: $MATCH_2'},
+        )
+        self.executor._exec_cmd(command)
+        assert self.varstore.get_variable('output_var') == 'First: test1, Second: test2, Third: test3'
+
+    def test_exec_cmd_search(self):
+        # Test mode "search"
+        self.varstore.set_variable('input_var', 'test1 test2 test3')
+        command = RegExCommand(
+            type='regex',
+            cmd='test\\d',
+            mode='search',
+            input='input_var',
+            output={'output_var': 'Found: $MATCH_0'},
+        )
+        self.executor._exec_cmd(command)
+        assert self.varstore.get_variable('output_var') == 'Found: test1'
+
+    def test_exec_cmd_sub(self):
+        # Test mode "sub"
+        self.varstore.set_variable('input_var', 'test1 test2 test3')
+        command = RegExCommand(
+            type='regex',
+            cmd='test',
+            mode='sub',
+            replace='TEST',
+            input='input_var',
+            output={'output_var': 'Replaced: $MATCH_0'},
+        )
+        self.executor._exec_cmd(command)
+        assert self.varstore.get_variable('output_var') == 'Replaced: TEST1 TEST2 TEST3'
+
+    def test_exec_cmd_findall_no_match(self):
+        # Test mode "findall" without matches
+        self.varstore.set_variable('input_var', 'no matches here')
+        command = RegExCommand(
+            type='regex',
+            cmd='test\\d',
+            mode='findall',
+            input='input_var',
+            output={'output_var': 'Found: $MATCH_0'},
+        )
+        self.executor._exec_cmd(command)
+        assert 'output_var' not in self.varstore.variables
+
+    def test_exec_cmd_split_no_match(self):
+        # Test mode "split" without matches
+        self.varstore.set_variable('input_var', 'no matches here')
+        command = RegExCommand(
+            type='regex', cmd='\\d', mode='split', input='input_var', output={'output_var': 'First: $MATCH_0'}
+        )
+        self.executor._exec_cmd(command)
+        assert self.varstore.get_variable('output_var') == 'First: no matches here'
+
+    def test_exec_cmd_search_no_match(self):
+        # Test mode "search" without matches
+        self.varstore.set_variable('input_var', 'no matches here')
+        command = RegExCommand(
+            type='regex',
+            cmd='test\\d',
+            mode='search',
+            input='input_var',
+            output={'output_var': 'Found: $MATCH_0'},
+        )
+        self.executor._exec_cmd(command)
+        assert 'output_var' not in self.varstore.variables
+
+    def test_exec_cmd_sub_no_match(self):
+        # Test mode "sub" without matches
+        self.varstore.set_variable('input_var', 'no matches here')
+        command = RegExCommand(
+            type='regex',
+            cmd='test',
+            mode='sub',
+            replace='TEST',
+            input='input_var',
+            output={'output_var': 'Replaced: $MATCH_0'},
+        )
+        self.executor._exec_cmd(command)
+        assert self.varstore.get_variable('output_var') == 'Replaced: no matches here'


### PR DESCRIPTION
This PR solves issue #71 

- adds a regex.yml example file for all modes
- adds error handling to playbook parsing
- logs informative error when regex mode is sub and replace is missing
- slight refactoring of forge_variable() and sub_needs_replace(), reduce duplicated code, ensure first match is always named MATCH_0 (even if only one match exists), ensure command always returns the result of the re.<mode> commands, i.e. if there is no string to substitute, the original input is returned.
- adds unit test for RegExCommand and RegExExecutor
output of regex.yml playbook:

![image](https://github.com/ait-testbed/attackmate/assets/68156005/11262e9d-03ed-43e7-8803-2b4a0cef8bde)
