### PR TITLE
playbook default location

### DIFF
--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -57,8 +57,7 @@ First Run
 =========
 
 Now we can run the playbook using the following command:
-(if no full path to a playbook file is given in the attackm8 command, attackmate will try to find the file in the directory attackmate/playbooks. 
-The playbooks directory is in .gitignore per default)
+(We can supply the full path to the playbook, otherwise the parser tries to find it in the current working directory or in the folder /etc/attackmate/playbooks)
 
 ::
 

--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -57,6 +57,8 @@ First Run
 =========
 
 Now we can run the playbook using the following command:
+(if no full path to a playbook file is given in the attackm8 command, attackmate will try to find the file in the directory attackmate/playbooks. 
+The playbooks directory is in .gitignore per default)
 
 ::
 

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,2 @@
+
+if no full path to a playbook file is given in the attackm8 command, attackmate will try to find the file in this directory attackmate/playbooks

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,2 +1,2 @@
 
-if no full path to a playbook file is given in the attackm8 command, attackmate will try to find the file in this directory attackmate/playbooks
+the playbooks directory is in .gitignore per default

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -144,6 +144,7 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     default_playbook_location = Path('/etc/attackmate/playbooks')
 
     playbook_file_path = Path(playbook_file)
+    target_file = ''
 
     # 1 # Check provided path
     if playbook_file_path.exists():
@@ -156,6 +157,8 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     # 3 # Check default playbook directory
     elif (default_playbook_location / playbook_file_path).exists():
         target_file = default_playbook_location / playbook_file_path
+    
+    logger.debug(f"Loading playbook file {target_file}")
 
     else:
         logger.error(

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -148,19 +148,23 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     # Construct the path to the playbooks directory relative to the venv root
     default_playbook_location = os.path.join(venv_root.parent, 'playbooks')
 
-    file_path = Path(playbook_file)
+    playbook_file_path = Path(playbook_file)
 
-    if file_path.exists():
-        target_file = file_path
+    # Check provided path
+    if playbook_file_path.exists():
+        target_file = playbook_file_path
     else:
-        # Try to load from default playbooks location + filename only
-        filename_only = file_path.name
-        target_file = default_playbook_location / filename_only
+        # Check default location + provided path
+        target_file = default_playbook_location / playbook_file_path
         if not target_file.exists():
-            logger.error(
-                f"Error: Playbook file '{filename_only}' does not exist in both the specified and default location."
-            )
-            exit(1)
+            # Check default location + filename only
+            filename_only = playbook_file_path.name
+            target_file = default_playbook_location / filename_only
+            if not target_file.exists():
+                logger.error(
+                    f"Error: Playbook file '{filename_only}' does not exist in both the specified and default locations."
+                )
+                exit(1)
 
     try:
         with open(target_file) as f:

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -153,7 +153,14 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     if file_path.exists():
         target_file = file_path
     else:
-        target_file = Path(default_playbook_location) / playbook_file
+        # Try to load from default playbooks location + filename only
+        filename_only = file_path.name
+        target_file = default_playbook_location / filename_only
+        if not target_file.exists():
+            logger.error(
+                f"Error: Playbook file '{filename_only}' does not exist in both the specified and default location."
+            )
+            exit(1)
 
     try:
         with open(target_file) as f:
@@ -163,6 +170,8 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     except OSError:
         logger.error(f'Error: Could not open playbook file {target_file}')
         exit(1)
+
+    # if this fails, also try extracting the filename only from the supplied path and try playbooks
 
 
 def parse_args():

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -159,7 +159,8 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
 
     else:
         logger.error(
-            f"Error: Playbook file not found under '{playbook_file_path}' or in the current directory or in '/etc/attackmate/playbooks'"
+            f"Error: Playbook file not found under '{playbook_file_path}' 
+            or in the current directory or in '/etc/attackmate/playbooks'"
         )
         exit(1)
 
@@ -172,7 +173,6 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
         logger.error(f'Error: Could not open playbook file {target_file}')
         exit(1)
 
-    # if this fails, also try extracting the filename only from the supplied path and try playbooks
 
 
 def parse_args():

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -159,8 +159,7 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
 
     else:
         logger.error(
-            f"Error: Playbook file not found under '{playbook_file_path}' 
-            or in the current directory or in '/etc/attackmate/playbooks'"
+            f"Error: Playbook file not found under '{playbook_file_path}' or in the current directory or in /etc/attackmate/playbooks"
         )
         exit(1)
 
@@ -172,7 +171,6 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     except OSError:
         logger.error(f'Error: Could not open playbook file {target_file}')
         exit(1)
-
 
 
 def parse_args():

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -144,27 +144,32 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     default_playbook_location = Path('/etc/attackmate/playbooks')
 
     playbook_file_path = Path(playbook_file)
-    target_file = ''
+    target_file = None
 
-    # 1 # Check provided path
-    if playbook_file_path.exists():
-        target_file = playbook_file_path
+    try:
+        # 1 # Check provided path
+        if playbook_file_path.exists():
+            target_file = playbook_file_path
 
-    # 2 # Check current working directory
-    elif (current_working_directory / playbook_file_path).exists():
-        target_file = current_working_directory / playbook_file_path
+        # 2 # Check current working directory
+        elif (current_working_directory / playbook_file_path).exists():
+            target_file = current_working_directory / playbook_file_path
 
-    # 3 # Check default playbook directory
-    elif (default_playbook_location / playbook_file_path).exists():
-        target_file = default_playbook_location / playbook_file_path
-    
-    logger.debug(f"Loading playbook file {target_file}")
+        # 3 # Check default playbook directory
+        elif (default_playbook_location / playbook_file_path).exists():
+            target_file = default_playbook_location / playbook_file_path
 
-    else:
-        logger.error(
-            f"Error: Playbook file not found under '{playbook_file_path}' or in the current directory or in /etc/attackmate/playbooks"
-        )
-        exit(1)
+        else:
+            logger.error(
+                f"Error: Playbook file not found under '{playbook_file_path}' or in the current directory or in /etc/attackmate/playbooks"
+            )
+            exit(1)
+
+    finally:
+        if target_file:
+            logger.debug(f'Playbook target filepath is set to: {target_file}')
+        else:
+            logger.debug('Playbook target filepath is not set')
 
     try:
         with open(target_file) as f:

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -158,7 +158,7 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
         target_file = default_playbook_location / playbook_file_path
         if not target_file.exists():
             # Check default location + filename only
-            filename_only = playbook_file_path.name
+            filename_only = Path(playbook_file_path.name)
             target_file = default_playbook_location / filename_only
             if not target_file.exists():
                 logger.error(

--- a/test/units/test_parseplaybook.py
+++ b/test/units/test_parseplaybook.py
@@ -5,8 +5,6 @@ from pathlib import Path
 import yaml
 from attackmate.__main__ import parse_playbook
 
-# import other frunciotn sfrom other modules to mock: yaml _load?
-
 
 # Mock Playbook class for validation
 class MockPlaybook:
@@ -43,18 +41,18 @@ def test_parse_playbook_valid_file(mock_logger, mock_playbook_file):
         'attackmate.__main__.yaml.safe_load', return_value=yaml.safe_load(sample_playbook_yaml)
     ), patch('attackmate.__main__.Playbook', MockPlaybook):
 
-        # Call the function with the path to the temporary playbook file
         result = parse_playbook(str(mock_playbook_file), mock_logger)
 
-        # Assertions
         assert result == 'MockPlaybookObject'
 
 
 def test_parse_playbook_nonexistent_file(mock_logger):
     non_existent_file = Path('/non/existent/path/playbook.yml')
+    error_message = (
+        f"Error: Playbook file not found under '{non_existent_file}' "
+        "or in the current directory or in /etc/attackmate/playbooks"
+    )
 
     with pytest.raises(SystemExit):
         parse_playbook(str(non_existent_file), mock_logger)
-    mock_logger.error.assert_called_with(
-        f"Error: Playbook file not found under '{non_existent_file}' or in the current directory or in /etc/attackmate/playbooks"
-    )
+    mock_logger.error.assert_called_with(error_message)

--- a/test/units/test_parseplaybook.py
+++ b/test/units/test_parseplaybook.py
@@ -1,0 +1,60 @@
+import pytest
+import logging
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+import yaml
+from attackmate.__main__ import parse_playbook
+
+# import other frunciotn sfrom other modules to mock: yaml _load?
+
+
+# Mock Playbook class for validation
+class MockPlaybook:
+    @staticmethod
+    def model_validate(data):
+        return 'MockPlaybookObject'
+
+
+# Sample YAML content for the playbook
+sample_playbook_yaml = """
+###
+commands:
+  - type: shell
+    cmd: ls
+
+"""
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock(spec=logging.Logger)
+
+
+@pytest.fixture
+def mock_playbook_file(tmp_path):
+    # Create a temporary playbook file with sample YAML content
+    playbook_file = tmp_path / 'playbook.yml'
+    playbook_file.write_text(sample_playbook_yaml)
+    return playbook_file
+
+
+def test_parse_playbook_valid_file(mock_logger, mock_playbook_file):
+    with patch(
+        'attackmate.__main__.yaml.safe_load', return_value=yaml.safe_load(sample_playbook_yaml)
+    ), patch('attackmate.__main__.Playbook', MockPlaybook):
+
+        # Call the function with the path to the temporary playbook file
+        result = parse_playbook(str(mock_playbook_file), mock_logger)
+
+        # Assertions
+        assert result == 'MockPlaybookObject'
+
+
+def test_parse_playbook_nonexistent_file(mock_logger):
+    non_existent_file = Path('/non/existent/path/playbook.yml')
+
+    with pytest.raises(SystemExit):
+        parse_playbook(str(non_existent_file), mock_logger)
+    mock_logger.error.assert_called_with(
+        f"Error: Playbook file not found under '{non_existent_file}' or in the current directory or in '/etc/attackmate/playbooks'"
+    )

--- a/test/units/test_parseplaybook.py
+++ b/test/units/test_parseplaybook.py
@@ -56,5 +56,5 @@ def test_parse_playbook_nonexistent_file(mock_logger):
     with pytest.raises(SystemExit):
         parse_playbook(str(non_existent_file), mock_logger)
     mock_logger.error.assert_called_with(
-        f"Error: Playbook file not found under '{non_existent_file}' or in the current directory or in '/etc/attackmate/playbooks'"
+        f"Error: Playbook file not found under '{non_existent_file}' or in the current directory or in /etc/attackmate/playbooks"
     )


### PR DESCRIPTION
This PR solves issue #64 

- check if the playbook-file is actually a valid filepath and use that
- if not, check if the playbook is inside the current directory
- if not, check if the playbook is in /etc/attackmate/playbooks

- adapt docs
- add unit tests for parse_playbook

![image](https://github.com/user-attachments/assets/55e9dfe1-d7f1-4c75-874a-402f7b5d176b)

