### PR TITLE
Bug 96 sliverexecutor ignores the file path setting

### DIFF
--- a/docs/source/playbook/commands/sliver-session.rst
+++ b/docs/source/playbook/commands/sliver-session.rst
@@ -19,11 +19,19 @@ List files and directories on the remote host
      - type: sliver-session
        cmd: ls
        remote_path: /etc
+       session: implant-name
 
 
 .. confval:: remote_path
 
    Path to list all files
+
+   :type: str
+   :required: ``True``
+
+.. confval:: session
+
+   The name of the sliver implant to connect to. Defined previously by the by sliver generate_implant command.
 
    :type: str
    :required: ``True``
@@ -41,6 +49,7 @@ Change the working directory
      - type: sliver-session
        cmd: cd
        remote_path: /home
+       session: implant-name
 
 
 .. confval:: remote_path
@@ -67,6 +76,7 @@ Print network connection information
        ipv4: True
        ipv6: False
        listening: True
+       session: implant-name
 
 
 .. confval:: tcp
@@ -121,6 +131,7 @@ Execute a program on the remote system
          - root
          - /etc/passwd
        output: True
+       session: implant-name
 
 
 .. confval:: exe
@@ -156,6 +167,7 @@ Create a remote directory.
      - type: sliver-session
        cmd: mkdir
        remote_path: /tmp/somedirectory
+       session: implant-name
 
 
 .. confval:: remote_path
@@ -177,6 +189,7 @@ View network interface configurations
    commands:
      - type: sliver-session
        cmd: ifconfig
+       session: implant-name
 
 ps
 --
@@ -189,6 +202,7 @@ List processes of the remote system
    commands:
      - type: sliver-session
        cmd: ps
+       session: implant-name
 
 
 pwd
@@ -202,6 +216,7 @@ Print working directory of the active session.
    commands:
      - type: sliver-session
        cmd: pwd
+       session: implant-name
 
 download
 --------
@@ -216,6 +231,7 @@ Download a file or directory from the remote system. Directories will be downloa
        cmd: download
        remote_path: /root
        recurse: True
+       session: implant-name
 
 
 .. confval:: remote_path
@@ -253,6 +269,7 @@ Upload a file to the remote system.
        cmd: upload
        remote_path: /tmp/somefile
        local_path: /home/user/somefile
+       session: implant-name
 
 .. confval:: remote_path
 
@@ -288,6 +305,7 @@ Dumps the process memory of a given pid to a local file.
        cmd: process_dump
        pid: 102
        local_path: /home/user/some_service.dump
+       session: implant-name
 
 .. confval:: pid
 

--- a/docs/source/playbook/commands/sliver.rst
+++ b/docs/source/playbook/commands/sliver.rst
@@ -109,11 +109,6 @@ Generate a new sliver binary and saves the implant to a given path or to /tmp/<n
    ###
    commands:
      - type: sliver
-       cmd: start_https_listener
-       host: 0.0.0.0
-       port: 443
-
-     - type: sliver
        cmd: generate_implant
        name: "linux_implant"
        target: linux/amd64

--- a/docs/source/playbook/commands/sliver.rst
+++ b/docs/source/playbook/commands/sliver.rst
@@ -152,7 +152,7 @@ Generate a new sliver binary and saves the implant to a given path or to /tmp/<n
 
 .. confval:: name
 
-   Name of the implant. 
+   Name of the implant.
    This name is the session used by the attackmate command 'sliver-session'.
 
    :type: str
@@ -160,7 +160,7 @@ Generate a new sliver binary and saves the implant to a given path or to /tmp/<n
 
 .. confval:: filepath
 
-   The local filepath to save the implant to. If none is given the implant is saven in /tmp.
+   The local filepath to save the implant to. If none is given the implant is saved in /tmp.
    The <name> will be random and have the format ^tmp[a-z0-9]{8}$.
 
 

--- a/docs/source/playbook/commands/sliver.rst
+++ b/docs/source/playbook/commands/sliver.rst
@@ -110,8 +110,10 @@ Generate a new sliver binary and saves the implant to a given path or to /tmp/<n
    commands:
      - type: sliver
        cmd: generate_implant
+       c2url: "https://myC2url.com"
        name: "linux_implant"
        target: linux/amd64
+       filepath: /path/to/implant/my_implant
 
 
 .. confval:: target
@@ -150,14 +152,17 @@ Generate a new sliver binary and saves the implant to a given path or to /tmp/<n
 
 .. confval:: name
 
-   Name of the Implant
+   Name of the implant. 
+   This name is the session used by the attackmate command 'sliver-session'.
 
    :type: str
    :required: True
 
 .. confval:: filepath
 
-   The local filepath to save the implant to.
+   The local filepath to save the implant to. If none is given the implant is saven in /tmp.
+   The <name> will be random and have the format ^tmp[a-z0-9]{8}$.
+
 
    :type: str
    :default: ``/tmp/<name>``

--- a/test/units/test_sliverexecutor.py
+++ b/test/units/test_sliverexecutor.py
@@ -47,7 +47,6 @@ def test_save_implant_without_filepath(setup_executor):
     implant = client_pb2.Generate()
     implant.File.Data = b'Test data'
 
-    # Mock tempfile.NamedTemporaryFile
     with patch('tempfile.NamedTemporaryFile') as mock_tempfile:
         # Create a mock file object
         mock_tempfile_instance = MagicMock()

--- a/test/units/test_sliverexecutor.py
+++ b/test/units/test_sliverexecutor.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+import pytest
+from unittest.mock import MagicMock, patch
+from attackmate.executors.sliver.sliverexecutor import SliverExecutor
+from sliver.protobuf import client_pb2
+
+
+@pytest.fixture
+def setup_executor():
+    # Mock dependencies and create a SliverExecutor instance
+    pm = MagicMock()  # Mock ProcessManager
+    varstore = MagicMock()  # Mock VariableStore
+    sliver_config = MagicMock()  # Mock SliverConfig
+    sliver_config.config_file = None
+    executor = SliverExecutor(pm, varstore=varstore, sliver_config=sliver_config)
+    return executor
+
+
+@pytest.fixture
+def temp_file():
+    # Create a temporary file and ensure it's removed after the test
+    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    temp_file.close()  # Close the file so it can be opened later
+    yield temp_file.name
+    os.remove(temp_file.name)
+
+
+def test_save_implant_with_filepath(setup_executor, temp_file):
+    executor = setup_executor
+    implant = client_pb2.Generate()
+    implant.File.Data = b'Test data'
+
+    # Mock os.path.exists to return False so the file is created
+    with patch('os.path.exists', return_value=False):
+        result = executor.save_implant(implant, temp_file)
+
+    assert result == temp_file
+    assert os.path.exists(temp_file)
+
+    with open(temp_file, 'rb') as f:
+        assert f.read() == b'Test data'
+
+
+def test_save_implant_without_filepath(setup_executor):
+    executor = setup_executor
+    implant = client_pb2.Generate()
+    implant.File.Data = b'Test data'
+
+    # Mock tempfile.NamedTemporaryFile
+    with patch('tempfile.NamedTemporaryFile') as mock_tempfile:
+        # Create a mock file object
+        mock_tempfile_instance = MagicMock()
+        mock_tempfile_instance.name = 'temp_file.bin'
+        mock_tempfile.return_value = mock_tempfile_instance
+
+        # Mock os.path.exists to return False so the file is created
+        with patch('os.path.exists', return_value=False), patch('os.remove') as mock_remove:
+
+            result = executor.save_implant(implant)
+
+        assert result == 'temp_file.bin'
+        assert os.path.exists('temp_file.bin')
+
+        with open('temp_file.bin', 'rb') as f:
+            assert f.read() == b'Test data'
+
+        mock_remove.assert_not_called()
+
+        os.remove('temp_file.bin')
+
+
+def test_save_implant_overwrite_file(setup_executor, temp_file):
+    executor = setup_executor
+    implant = client_pb2.Generate()
+    implant.File.Data = b'New data'
+
+    # Create a file to be overwritten
+    with open(temp_file, 'wb') as f:
+        f.write(b'Old data')
+
+    result = executor.save_implant(implant, temp_file)
+
+    assert result == temp_file
+    assert os.path.exists(temp_file)
+
+    with open(temp_file, 'rb') as f:
+        assert f.read() == b'New data'
+
+
+def test_save_implant_set_variable_called(setup_executor, temp_file):
+    executor = setup_executor
+    implant = client_pb2.Generate()
+    implant.File.Data = b'Test data'
+
+    # Mock os.path.exists to return False so the file is created
+    with patch('os.path.exists', return_value=False):
+        executor.save_implant(implant, temp_file)
+
+    executor.varstore.set_variable.assert_called_once_with('LAST_SLIVER_IMPLANT', temp_file)


### PR DESCRIPTION
This PR fixes issue #96 

- adds optional argument filepath the save_implant() 
- updates sliver docs
- added unit tests for sliver executor save_implant()

The `client_pb2.ImplantConfig` has no attribute for the filepath, command.filepath therefore has to be given separately to the `save_implant` function.

**Testing**
cmd: generate_implant. First run with filepath argument, second without filepath argument (commented out, default is used)
![Screenshot from 2024-07-25 10-07-27](https://github.com/user-attachments/assets/0be8e58a-ca4c-41d7-9090-e75a1bd8f273)

