### PR TITLE
add support for metadata

### DIFF
--- a/src/attackmate/executors/baseexecutor.py
+++ b/src/attackmate/executors/baseexecutor.py
@@ -25,8 +25,9 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
     _exec_cmd()
 
     """
+
     def __init__(self, pm: ProcessManager, variablestore: VariableStore, cmdconfig=CommandConfig()):
-        """ Constructor for BaseExecutor
+        """Constructor for BaseExecutor
 
         Parameters
         ----------
@@ -43,7 +44,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
         self.output = logging.getLogger('output')
 
     def run(self, command: BaseCommand):
-        """ Execute the command
+        """Execute the command
 
         This method is executed by AttackMate and
         executes the given command. This method sets the
@@ -72,15 +73,13 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
             self.exec(self.replace_variables(command))
 
     def log_command(self, command):
-        """ Log starting-status of the command
-
-        """
-        self.logger.info(f"Executing '{command}'")
+        """Log starting-status of the command"""
+        self.logger.info(f"Executing '{command}'", extra={'metadata': command.metadata})
 
     def save_output(self, command: BaseCommand, result: Result):
-        """ Save output of command to a file. This method will
-            ignore all exceptions and won't stop the programm
-            on error.
+        """Save output of command to a file. This method will
+        ignore all exceptions and won't stop the programm
+        on error.
         """
         if command.save:
             try:

--- a/src/attackmate/executors/common/debugexecutor.py
+++ b/src/attackmate/executors/common/debugexecutor.py
@@ -12,7 +12,7 @@ from attackmate.schemas.debug import DebugCommand
 class DebugExecutor(BaseExecutor):
 
     def log_command(self, command: DebugCommand):
-        self.logger.warn(f"Debug: '{command.cmd}'")
+        self.logger.warn(f"Debug: '{command.cmd}'", extra={'metadata': command.metadata})
         if command.varstore:
             self.logger.warn(self.varstore.variables)
 

--- a/src/attackmate/executors/father/fatherexecutor.py
+++ b/src/attackmate/executors/father/fatherexecutor.py
@@ -40,16 +40,16 @@ class FatherExecutor(BaseExecutor):
 #endif
 """
         template_vars = {
-                         'GID': command.gid,
-                         'SOURCEPORT': command.srcport,
-                         'EPOCH_TIME': command.epochtime,
-                         'ENV_VAR': command.env_var,
-                         'FILE_PREFIX': command.file_prefix,
-                         'PRELOAD_FILE': command.preload_file,
-                         'HIDDENPORT': command.hiddenport,
-                         'SHELL_PASS': command.shell_pass,
-                         'INSTALL_PATH': command.install_path
-                        }
+            'GID': command.gid,
+            'SOURCEPORT': command.srcport,
+            'EPOCH_TIME': command.epochtime,
+            'ENV_VAR': command.env_var,
+            'FILE_PREFIX': command.file_prefix,
+            'PRELOAD_FILE': command.preload_file,
+            'HIDDENPORT': command.hiddenport,
+            'SHELL_PASS': command.shell_pass,
+            'INSTALL_PATH': command.install_path,
+        }
         template = Template(config)
         substi = template.safe_substitute(template_vars)
         self.logger.debug(substi)
@@ -57,14 +57,14 @@ class FatherExecutor(BaseExecutor):
             f.write(substi)
 
     def log_command(self, command: FatherCommand):
-        self.logger.info('Generating Father-Binary')
+        self.logger.info('Generating Father-Binary', extra={'metadata': command.metadata})
 
     def _exec_cmd(self, command: FatherCommand) -> Result:
         if platform.system() != 'Linux':
             return Result('Compiling Father only works for Linux!', 1)
 
         data_path = os.path.join(Path(__file__).parents[2], 'data', 'Father.tar.gz')
-        
+
         if command.local_path:
             father_path = command.local_path
         else:
@@ -74,11 +74,13 @@ class FatherExecutor(BaseExecutor):
         tar = tarfile.open(data_path)
         tar.extractall(father_path)
         self.set_config(command, os.path.join(father_path, 'Father', 'src', 'config.h'))
-        result = subprocess.run(command.build_command,
-                                shell=True,
-                                cwd=os.path.join(father_path, 'Father'),
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT)
+        result = subprocess.run(
+            command.build_command,
+            shell=True,
+            cwd=os.path.join(father_path, 'Father'),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
         output = result.stdout.decode('utf-8', 'ignore')
 
         if result.returncode != 0:

--- a/src/attackmate/executors/http/httpclientexecutor.py
+++ b/src/attackmate/executors/http/httpclientexecutor.py
@@ -14,7 +14,9 @@ from attackmate.execexception import ExecException
 
 class HttpClientExecutor(BaseExecutor):
     def log_command(self, command: HttpClientCommand):
-        self.logger.info(f'Performing HTTP[{command.cmd}] to {command.url}')
+        self.logger.info(
+            f'Performing HTTP[{command.cmd}] to {command.url}', extra={'metadata': command.metadata}
+        )
 
     def generate_headers(self, command: HttpClientCommand) -> dict[str, str]:
         if not command.headers:
@@ -39,26 +41,29 @@ class HttpClientExecutor(BaseExecutor):
         return content
 
     def request_http2(self, command: HttpClientCommand) -> httpx.Response:
-        client = httpx.Client(http2=True,
-                              headers=self.generate_headers(command),
-                              cookies=command.cookies,
-                              verify=command.verify)
-        response = client.request(command.cmd,
-                                  command.url,
-                                  content=self.load_content(command.local_path),
-                                  follow_redirects=command.follow,
-                                  data=command.data)
+        client = httpx.Client(
+            http2=True, headers=self.generate_headers(command), cookies=command.cookies, verify=command.verify
+        )
+        response = client.request(
+            command.cmd,
+            command.url,
+            content=self.load_content(command.local_path),
+            follow_redirects=command.follow,
+            data=command.data,
+        )
         return response
 
     def request(self, command: HttpClientCommand) -> httpx.Response:
-        return httpx.request(command.cmd,
-                             command.url,
-                             content=self.load_content(command.local_path),
-                             headers=self.generate_headers(command),
-                             cookies=command.cookies,
-                             data=command.data,
-                             follow_redirects=command.follow,
-                             verify=command.verify)
+        return httpx.request(
+            command.cmd,
+            command.url,
+            content=self.load_content(command.local_path),
+            headers=self.generate_headers(command),
+            cookies=command.cookies,
+            data=command.data,
+            follow_redirects=command.follow,
+            verify=command.verify,
+        )
 
     def _exec_cmd(self, command: HttpClientCommand) -> Result:
         try:

--- a/src/attackmate/executors/http/webservexecutor.py
+++ b/src/attackmate/executors/http/webservexecutor.py
@@ -45,8 +45,7 @@ class WebServe(HTTPServer):
 
     def finish_request(self, request, client_address):
         try:
-            self.RequestHandlerClass(request, client_address, self,
-                                     local_path=self.local_path)
+            self.RequestHandlerClass(request, client_address, self, local_path=self.local_path)
         except ConnectionResetError:
             pass
 
@@ -54,7 +53,10 @@ class WebServe(HTTPServer):
 class WebServExecutor(BaseExecutor):
 
     def log_command(self, command: WebServCommand):
-        self.logger.info(f'Serving {command.local_path} via HTTP on Port {command.port}')
+        self.logger.info(
+            f'Serving {command.local_path} via HTTP on Port {command.port}',
+            extra={'metadata': command.metadata},
+        )
 
     def _exec_cmd(self, command: WebServCommand) -> Result:
         address = (command.address, CmdVars.variable_to_int('Port', command.port))

--- a/src/attackmate/executors/metasploit/msfexecutor.py
+++ b/src/attackmate/executors/metasploit/msfexecutor.py
@@ -15,10 +15,15 @@ from multiprocessing.queues import JoinableQueue
 
 
 class MsfModuleExecutor(BaseExecutor):
-    def __init__(self, pm: ProcessManager, cmdconfig=None, *,
-                 varstore: VariableStore,
-                 msfconfig=None,
-                 msfsessionstore: MsfSessionStore):
+    def __init__(
+        self,
+        pm: ProcessManager,
+        cmdconfig=None,
+        *,
+        varstore: VariableStore,
+        msfconfig=None,
+        msfsessionstore: MsfSessionStore,
+    ):
         self.msfconfig = msfconfig
         self.sessionstore = msfsessionstore
         self.msf = None
@@ -46,7 +51,7 @@ class MsfModuleExecutor(BaseExecutor):
         if self.msf is None:
             self.logger.debug('Connecting to msf-server...')
             self.connect(self.msfconfig)
-        self.logger.info(f"Executing Msf-Module: '{command.cmd}'")
+        self.logger.info(f"Executing Msf-Module: '{command.cmd}'", extra={'metadata': command.metadata})
 
     def prepare_payload(self, command: MsfModuleCommand):
         self.logger.debug(f'Using payload: {command.payload}')
@@ -74,8 +79,7 @@ class MsfModuleExecutor(BaseExecutor):
             self.logger.debug(f'module_type: {command.module_type()}')
             self.logger.debug(f'module_path: {command.module_path()}')
             if self.msf is not None:
-                exploit = self.msf.modules.use(command.module_type(),
-                                               command.module_path())
+                exploit = self.msf.modules.use(command.module_type(), command.module_path())
             else:
                 raise ExecException('Problems with the metasploit connection')
             self.logger.debug(exploit.description)
@@ -114,14 +118,13 @@ class MsfModuleExecutor(BaseExecutor):
             self.logger.debug(command.module_path())
             if command.module_path() == 'multi/manage/shell_to_meterpreter':
                 self.logger.debug('Waiting for increased session..')
-                self.sessionstore.wait_for_increased_session(command.creates_session,
-                                                             result['uuid'],
-                                                             self.msf.sessions,
-                                                             self.child_queue)
+                self.sessionstore.wait_for_increased_session(
+                    command.creates_session, result['uuid'], self.msf.sessions, self.child_queue
+                )
             else:
-                self.sessionstore.wait_for_session(command.creates_session,
-                                                   result['uuid'],
-                                                   self.msf.sessions, self.child_queue)
+                self.sessionstore.wait_for_session(
+                    command.creates_session, result['uuid'], self.msf.sessions, self.child_queue
+                )
             return Result('', 0)
         cid = self.msf.consoles.console().cid
         output = self.msf.consoles.console(cid).run_module_with_output(exploit, payload=payload)

--- a/src/attackmate/executors/metasploit/msfpayloadexecutor.py
+++ b/src/attackmate/executors/metasploit/msfpayloadexecutor.py
@@ -19,9 +19,9 @@ from attackmate.schemas.config import CommandConfig
 
 
 class MsfPayloadExecutor(BaseExecutor):
-    def __init__(self, pm: ProcessManager, varstore: VariableStore,
-                 cmdconfig=CommandConfig(), *,
-                 msfconfig=None):
+    def __init__(
+        self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig(), *, msfconfig=None
+    ):
         self.msfconfig = msfconfig
         self.msf = None
         self.tempfilestore: list[Any] = []
@@ -41,7 +41,7 @@ class MsfPayloadExecutor(BaseExecutor):
         if self.msf is None:
             self.logger.debug('Connecting to msf-server...')
             self.connect(self.msfconfig)
-        self.logger.info(f"Generating Msf-Payload: '{command.cmd}'")
+        self.logger.info(f"Generating Msf-Payload: '{command.cmd}'", extra={'metadata': command.metadata})
 
     def prepare_payload(self, command: MsfPayloadCommand):
         if not self.msf:

--- a/src/attackmate/executors/metasploit/msfsessionexecutor.py
+++ b/src/attackmate/executors/metasploit/msfsessionexecutor.py
@@ -12,10 +12,15 @@ from attackmate.processmanager import ProcessManager
 
 
 class MsfSessionExecutor(BaseExecutor):
-    def __init__(self, pm: ProcessManager, cmdconfig=None, *,
-                 varstore: VariableStore,
-                 msfconfig=None,
-                 msfsessionstore: MsfSessionStore):
+    def __init__(
+        self,
+        pm: ProcessManager,
+        cmdconfig=None,
+        *,
+        varstore: VariableStore,
+        msfconfig=None,
+        msfsessionstore: MsfSessionStore,
+    ):
         self.msfconfig = msfconfig
         self.sessionstore = msfsessionstore
         self.msf = None
@@ -42,7 +47,9 @@ class MsfSessionExecutor(BaseExecutor):
         if self.msf is None:
             self.logger.debug('Connecting to msf-server...')
             self.connect(self.msfconfig)
-        self.logger.info(f"Executing Msf-Session-Command: '{command.cmd}'")
+        self.logger.info(
+            f"Executing Msf-Session-Command: '{command.cmd}'", extra={'metadata': command.metadata}
+        )
 
     def _exec_cmd(self, command: MsfSessionCommand) -> Result:
         if self.msf is None:
@@ -70,8 +77,9 @@ class MsfSessionExecutor(BaseExecutor):
             if not return_empty:
                 self.logger.info('Executing a msf-command')
                 try:
-                    output = self.msf.sessions.session(session_id).run_with_output(command.cmd,
-                                                                                   command.end_str)
+                    output = self.msf.sessions.session(session_id).run_with_output(
+                        command.cmd, command.end_str
+                    )
                 except TypeError:
                     self.logger.debug('Fallback: First raw-write again and then raw-read data in msf-session')
                     self.msf.sessions.session(session_id).write(command.cmd)

--- a/src/attackmate/executors/sliver/sliverexecutor.py
+++ b/src/attackmate/executors/sliver/sliverexecutor.py
@@ -22,9 +22,7 @@ from attackmate.processmanager import ProcessManager
 
 class SliverExecutor(BaseExecutor):
 
-    def __init__(self, pm: ProcessManager, cmdconfig=None, *,
-                 varstore: VariableStore,
-                 sliver_config=None):
+    def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore, sliver_config=None):
         self.sliver_config = sliver_config
         self.client = None
         self.tempfilestore: list[Any] = []
@@ -46,21 +44,21 @@ class SliverExecutor(BaseExecutor):
         self.logger.debug(f'{command.host=}')
         if self.client is None:
             raise ExecException('SliverClient is not defined')
-        listener = await self.client.start_https_listener(command.host,
-                                                          CmdVars.variable_to_int('port', command.port),
-                                                          command.website,
-                                                          command.domain,
-                                                          b'',
-                                                          b'',
-                                                          command.acme,
-                                                          command.persistent,
-                                                          command.enforce_otp,
-                                                          command.randomize_jarm,
-                                                          CmdVars.variable_to_int('long_poll_timeout',
-                                                                                  command.long_poll_timeout),
-                                                          CmdVars.variable_to_int('long_poll_jitter',
-                                                                                  command.long_poll_jitter),
-                                                          CmdVars.variable_to_int('timeout', command.timeout))
+        listener = await self.client.start_https_listener(
+            command.host,
+            CmdVars.variable_to_int('port', command.port),
+            command.website,
+            command.domain,
+            b'',
+            b'',
+            command.acme,
+            command.persistent,
+            command.enforce_otp,
+            command.randomize_jarm,
+            CmdVars.variable_to_int('long_poll_timeout', command.long_poll_timeout),
+            CmdVars.variable_to_int('long_poll_jitter', command.long_poll_jitter),
+            CmdVars.variable_to_int('timeout', command.timeout),
+        )
         self.result = Result(f'JobID: {listener.JobID}', 0)
 
     def prepare_implant_config(self, command: SliverGenerateCommand) -> client_pb2.ImplantConfig:
@@ -88,8 +86,7 @@ class SliverExecutor(BaseExecutor):
         implconfig.C2.extend([c2])
         implconfig.IsBeacon = command.IsBeacon
         if command.IsBeacon:
-            implconfig.BeaconInterval = CmdVars.variable_to_int('BeaconInterval',
-                                                                command.BeaconInterval)
+            implconfig.BeaconInterval = CmdVars.variable_to_int('BeaconInterval', command.BeaconInterval)
         implconfig.RunAtLoad = command.RunAtLoad
         implconfig.Evasion = command.Evasion
         target = command.target.split('/')
@@ -137,7 +134,7 @@ class SliverExecutor(BaseExecutor):
         self.result.returncode = 0
 
     def log_command(self, command: BaseCommand):
-        self.logger.info(f"Executing Sliver-command: '{command.cmd}'")
+        self.logger.info(f"Executing Sliver-command: '{command.cmd}'", extra={'metadata': command.metadata})
         loop = asyncio.get_event_loop()
         coro = self.connect()
         loop.run_until_complete(coro)

--- a/src/attackmate/executors/sliver/sliversessionexecutor.py
+++ b/src/attackmate/executors/sliver/sliversessionexecutor.py
@@ -11,17 +11,26 @@ import time
 from sliver import SliverClientConfig, SliverClient
 from sliver.session import InteractiveSession
 from sliver.beacon import InteractiveBeacon
+
 # from sliver.protobuf import client_pb2
 from attackmate.variablestore import VariableStore
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.execexception import ExecException
 from attackmate.result import Result
-from attackmate.schemas.sliver import (SliverSessionCDCommand, SliverSessionCommand,
-                                       SliverSessionDOWNLOADCommand, SliverSessionEXECCommand,
-                                       SliverSessionLSCommand, SliverSessionNETSTATCommand,
-                                       SliverSessionPROCDUMPCommand, SliverSessionSimpleCommand,
-                                       SliverSessionMKDIRCommand, SliverSessionTERMINATECommand,
-                                       SliverSessionUPLOADCommand, SliverSessionRMCommand)
+from attackmate.schemas.sliver import (
+    SliverSessionCDCommand,
+    SliverSessionCommand,
+    SliverSessionDOWNLOADCommand,
+    SliverSessionEXECCommand,
+    SliverSessionLSCommand,
+    SliverSessionNETSTATCommand,
+    SliverSessionPROCDUMPCommand,
+    SliverSessionSimpleCommand,
+    SliverSessionMKDIRCommand,
+    SliverSessionTERMINATECommand,
+    SliverSessionUPLOADCommand,
+    SliverSessionRMCommand,
+)
 from datetime import datetime, timedelta
 from tabulate import tabulate
 from attackmate.executors.features.cmdvars import CmdVars
@@ -30,9 +39,7 @@ from attackmate.processmanager import ProcessManager
 
 class SliverSessionExecutor(BaseExecutor):
 
-    def __init__(self, pm: ProcessManager, cmdconfig=None, *,
-                 varstore: VariableStore,
-                 sliver_config=None):
+    def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore, sliver_config=None):
         self.sliver_config = sliver_config
         self.client = None
         self.client_config = None
@@ -179,16 +186,21 @@ class SliverSessionExecutor(BaseExecutor):
                 uid = str(entry.UID)
             else:
                 uid = ''
-            lines.append((entry.Protocol,
-                          entry.LocalAddr.Ip + ':' + str(entry.LocalAddr.Port),
-                          entry.RemoteAddr.Ip,
-                          state,
-                          str(entry.Process.Pid) + '/' + entry.Process.Executable,
-                          uid))
+            lines.append(
+                (
+                    entry.Protocol,
+                    entry.LocalAddr.Ip + ':' + str(entry.LocalAddr.Port),
+                    entry.RemoteAddr.Ip,
+                    state,
+                    str(entry.Process.Pid) + '/' + entry.Process.Executable,
+                    uid,
+                )
+            )
         output = '\n'
-        output += tabulate(lines, headers=['Protocol', 'Local Address',
-                                           'Foreign Address', 'State',
-                                           'PID/Program Name', 'UID'])
+        output += tabulate(
+            lines,
+            headers=['Protocol', 'Local Address', 'Foreign Address', 'State', 'PID/Program Name', 'UID'],
+        )
         output += '\n'
         self.result = Result(output, 0)
 
@@ -214,14 +226,14 @@ class SliverSessionExecutor(BaseExecutor):
         self.result = Result(f'Terminated process {term.Pid}', 0)
 
     def log_command(self, command: SliverSessionCommand):
-        self.logger.info(f"Executing Sliver-Session-command: '{command.cmd}'")
+        self.logger.info(
+            f"Executing Sliver-Session-command: '{command.cmd}'", extra={'metadata': command.metadata}
+        )
         loop = asyncio.get_event_loop()
         coro = self.connect()
         loop.run_until_complete(coro)
 
-    async def get_session_or_beacon(self,
-                                    name,
-                                    beacon=False) -> InteractiveBeacon | InteractiveSession:
+    async def get_session_or_beacon(self, name, beacon=False) -> InteractiveBeacon | InteractiveSession:
         if beacon:
             return await self.get_beacon_by_name(name)
         else:

--- a/src/attackmate/executors/ssh/sshexecutor.py
+++ b/src/attackmate/executors/ssh/sshexecutor.py
@@ -7,9 +7,7 @@ ssh.
 
 from paramiko.client import SSHClient
 from paramiko import AutoAddPolicy
-from paramiko.ssh_exception import (BadHostKeyException,
-                                    AuthenticationException,
-                                    SSHException)
+from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.execexception import ExecException
 from attackmate.executors.ssh.interactfeature import Interactive
@@ -64,7 +62,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
 
     def log_command(self, command: SSHCommand):
         self.cache_settings(command)
-        self.logger.info(f"Executing SSH-Command: '{command.cmd}'")
+        self.logger.info(f"Executing SSH-Command: '{command.cmd}'", extra={'metadata': command.metadata})
 
     def connect_jmphost(self, command: SSHCommand):
         jmp = SSHClient()
@@ -84,9 +82,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
         jmp.connect(**kwargs)
         transport = jmp.get_transport()
         if transport:
-            sock = transport.open_channel(
-                    'direct-tcpip', (self.hostname, self.port), ('', 0)
-            )
+            sock = transport.open_channel('direct-tcpip', (self.hostname, self.port), ('', 0))
         else:
             raise ExecException(f'Could not get transport of SSH-Jumphost {self.jmp_hostname}')
         return sock
@@ -117,7 +113,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             passphrase=self.passphrase,
             key_filename=self.key_filename,
             timeout=self.timeout,
-            sock=jmp_sock
+            sock=jmp_sock,
         )
         client.connect(**kwargs)
         if command.creates_session is not None:

--- a/src/attackmate/schemas/base.py
+++ b/src/attackmate/schemas/base.py
@@ -17,16 +17,17 @@ def check_var_pattern(value: str, info: ValidationInfo) -> str:
     return value
 
 
-StringNumber = Annotated[Optional[str | int],
-                         BeforeValidator(transform_int_to_str),
-                         AfterValidator(check_var_pattern)]
+StringNumber = Annotated[
+    Optional[str | int], BeforeValidator(transform_int_to_str), AfterValidator(check_var_pattern)
+]
 
 # Like StringNumber but without checks for valid $variable
 StrInt = Annotated[Optional[str | int], BeforeValidator(transform_int_to_str)]
 
+
 class BaseCommand(BaseModel):
     def list_template_vars(self) -> List[str]:
-        """ Get a list of all variables that can be used as templates
+        """Get a list of all variables that can be used as templates
 
         Returns a List with all member-names that can be used as
         templates for the VariableStore. Basically all members
@@ -56,3 +57,4 @@ class BaseCommand(BaseModel):
     cmd: str
     background: bool = False
     kill_on_exit: bool = True
+    metadata: Optional[str] = ''


### PR DESCRIPTION
This PR relates to issue #76 - 
adds support for metadata in logging to attackmate.log

- create custom adapter to add extra argument metadata to logger
- add optional attribute "metadata" to BaseCommand class
- adapt logging in commands to include metadata