### PR TITLE
Feature 24 remove validate prompt bool from ssh command

### DIFF
--- a/docs/source/playbook/commands/ssh.rst
+++ b/docs/source/playbook/commands/ssh.rst
@@ -180,7 +180,6 @@ Execute commands on a remote server via SSH.
 
    In interactive-mode the command will try reading the output for a certain amount of seconds. If the output
    ends with any string found in ``prompts``, the command will stop immediately.
-   If ``prompts`` is an empty list, no prompt checking will be performed. 
 
    :type: list[str]
    :default: ``["$ ", "# ", "> "]``
@@ -188,7 +187,6 @@ Execute commands on a remote server via SSH.
    .. code-block:: yaml
 
       vars:
-        $SERVER_ADDRESS: 192.42.0.254
         $SSH_SERVER: 10.10.10.19
 
       commands:
@@ -207,6 +205,25 @@ Execute commands on a remote server via SSH.
           creates_session: "attacker"
 
 
+   If ``prompts`` is an empty list, no prompt checking will be performed.
+
+   .. code-block:: yaml
+
+      vars:
+        $SSH_SERVER: 10.10.10.19
+
+      commands:
+        # creates new ssh-connection and session
+        - type: ssh
+          cmd: "id\n"
+          interactive: True
+          prompts: []
+          hostname: $SSH_SERVER
+          username: aecid
+          password: password
+          creates_session: "attacker"
+
+
 .. confval:: bin
 
    Enable binary mode. In this mode only hex-characters are allowed.
@@ -216,7 +233,7 @@ Execute commands on a remote server via SSH.
 
    .. code-block:: yaml
 
-      vars: 
+      vars:
         $SERVER_ADDRESS: 192.42.0.254
         $SSH_SERVER: 10.10.10.19
 

--- a/docs/source/playbook/commands/ssh.rst
+++ b/docs/source/playbook/commands/ssh.rst
@@ -180,6 +180,7 @@ Execute commands on a remote server via SSH.
 
    In interactive-mode the command will try reading the output for a certain amount of seconds. If the output
    ends with any string found in ``prompts``, the command will stop immediately.
+   If ``prompts`` is an empty list, no prompt checking will be performed.
 
    :type: list[str]
    :default: ``["$ ", "# ", "> "]``
@@ -205,15 +206,13 @@ Execute commands on a remote server via SSH.
           creates_session: "attacker"
 
 
-   If ``prompts`` is an empty list, no prompt checking will be performed.
-
    .. code-block:: yaml
 
       vars:
         $SSH_SERVER: 10.10.10.19
 
       commands:
-        # creates new ssh-connection and session
+        # prompts is an empty list
         - type: ssh
           cmd: "id\n"
           interactive: True

--- a/docs/source/playbook/commands/ssh.rst
+++ b/docs/source/playbook/commands/ssh.rst
@@ -180,6 +180,7 @@ Execute commands on a remote server via SSH.
 
    In interactive-mode the command will try reading the output for a certain amount of seconds. If the output
    ends with any string found in ``prompts``, the command will stop immediately.
+   If ``prompts`` is an empty list, no prompt checking will be performed. 
 
    :type: list[str]
    :default: ``["$ ", "# ", "> "]``

--- a/src/attackmate/executors/ssh/interactfeature.py
+++ b/src/attackmate/executors/ssh/interactfeature.py
@@ -7,13 +7,13 @@ from attackmate.execexception import ExecException
 from attackmate.executors.ssh.sessionstore import SessionStore
 
 
-class Interactive():
+class Interactive:
     def __init__(self):
         self.timer = None
         self.logger = logging.getLogger('playbook')
 
-    def check_prompt(self, output: str, prompts: list[str], validate_prompt: bool = True) -> bool:
-        if output and validate_prompt:
+    def check_prompt(self, output: str, prompts: list[str]) -> bool:
+        if output and prompts:
             for p in prompts:
                 if output.endswith(p):
                     self.logger.debug('found prompt!')

--- a/src/attackmate/executors/ssh/sshexecutor.py
+++ b/src/attackmate/executors/ssh/sshexecutor.py
@@ -7,9 +7,7 @@ ssh.
 
 from paramiko.client import SSHClient
 from paramiko import AutoAddPolicy
-from paramiko.ssh_exception import (BadHostKeyException,
-                                    AuthenticationException,
-                                    SSHException)
+from paramiko.ssh_exception import BadHostKeyException, AuthenticationException, SSHException
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.execexception import ExecException
 from attackmate.executors.ssh.interactfeature import Interactive
@@ -84,9 +82,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
         jmp.connect(**kwargs)
         transport = jmp.get_transport()
         if transport:
-            sock = transport.open_channel(
-                    'direct-tcpip', (self.hostname, self.port), ('', 0)
-            )
+            sock = transport.open_channel('direct-tcpip', (self.hostname, self.port), ('', 0))
         else:
             raise ExecException(f'Could not get transport of SSH-Jumphost {self.jmp_hostname}')
         return sock
@@ -117,7 +113,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             passphrase=self.passphrase,
             key_filename=self.key_filename,
             timeout=self.timeout,
-            sock=jmp_sock
+            sock=jmp_sock,
         )
         client.connect(**kwargs)
         if command.creates_session is not None:
@@ -146,7 +142,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
                         if stdout.channel.recv_ready():
                             tmp = stdout.channel.recv(1025).decode('utf-8', 'ignore')
                             output += tmp
-                            self.check_prompt(output, command.prompts, command.validate_prompt)
+                            self.check_prompt(output, command.prompts)
                 else:
                     stdin, stdout, stderr = client.exec_command(command.cmd)
                     output = stdout.read().decode('utf-8', 'ignore')

--- a/src/attackmate/schemas/ssh.py
+++ b/src/attackmate/schemas/ssh.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Literal
+from typing import Optional, Literal
 from pydantic import ValidationInfo, field_validator
 from .base import BaseCommand, StringNumber
 
@@ -29,9 +29,8 @@ class SSHBase(BaseCommand):
 class SSHCommand(SSHBase):
     type: Literal['ssh']
     interactive: bool = False
-    validate_prompt: bool = True
     command_timeout: StringNumber = '15'
-    prompts: List[str] = ['$ ', '# ', '> ']
+    prompts: list[str] = ['$ ', '# ', '> ']
     bin: bool = False
 
 

--- a/src/attackmate/schemas/ssh.py
+++ b/src/attackmate/schemas/ssh.py
@@ -1,4 +1,4 @@
-from typing import Optional, Literal
+from typing import Optional, Literal, List
 from pydantic import ValidationInfo, field_validator
 from .base import BaseCommand, StringNumber
 
@@ -30,7 +30,7 @@ class SSHCommand(SSHBase):
     type: Literal['ssh']
     interactive: bool = False
     command_timeout: StringNumber = '15'
-    prompts: list[str] = ['$ ', '# ', '> ']
+    prompts: List[str] = ['$ ', '# ', '> ']
     bin: bool = False
 
 


### PR DESCRIPTION
This PR relates to issue #24 

- remove validate_prompt bool
- use an empty list for not validating prompts instead