### PR TITLE
Feature 108 add regex operation to conditionals

### DIFF
--- a/docs/source/playbook/commands/index.rst
+++ b/docs/source/playbook/commands/index.rst
@@ -122,11 +122,16 @@ Every command, regardless of the type has the following general options:
    * var1 <= var2
    * var1 > var2
    * var1 >= var2
+   * string !~ pattern
+   * string =~ pattern
    * not var
    * var
    * None
 
    :type: str(condition)
+
+   The =~ operator is used to check if a string matches a regular expression pattern.
+   The !~ operator is used to check if a string does not match a regular expression pattern.
 
    .. code-block:: yaml
 
@@ -145,6 +150,12 @@ Every command, regardless of the type has the following general options:
         - type: shell
           cmd: kill $KILLPID
           only_if: $KILLPID > 1
+
+        # Execute this command only if the regex pattern is found
+        - type: shell
+          cmd: echo "regex match found"
+          only_if: some_string =~ some[_]?string
+
 
 .. confval:: background
 

--- a/test/units/test_conditionals.py
+++ b/test/units/test_conditionals.py
@@ -54,7 +54,6 @@ class TestConditionals:
         assert Conditional.test('1 is True')
         assert Conditional.test('0 is True') is False
 
-
     def test_exceptions(self):
         with pytest.raises(ConditionalError, match='Unknown Condition:'):
             Conditional.test('{"a":1, **d}')
@@ -66,3 +65,36 @@ class TestConditionals:
             Conditional.test('not (a + b)')
         with pytest.raises(ConditionalError, match='Unknown compare operation'):
             Conditional.test('a in b')
+
+    def test_regex(self):
+        # exact matches
+        assert Conditional.test('foo =~ foo') is True
+        assert Conditional.test('foo =~ bar') is False
+        assert Conditional.test('foo !~ foo') is False
+        assert Conditional.test('foo !~ bar') is True
+
+        assert Conditional.test('foo =~ foo') is True
+        assert Conditional.test('foo =~ bar') is False
+        assert Conditional.test('foo !~ foo') is False
+        assert Conditional.test('foo !~ bar') is True
+
+        # matches somewhere in the string
+        assert Conditional.test('somethingfoo =~ foo') is True
+        assert Conditional.test('foosomething =~ bar') is False
+        assert Conditional.test('somehtingfoo !~ foo') is False
+        assert Conditional.test('foosomething !~ bar') is True
+
+        # matches with wildcards and ranges
+        assert Conditional.test('hello =~ h.llo') is True  # Single character wildcard
+        assert Conditional.test('hello =~ h.*o') is True  # Zero or more characters
+        assert Conditional.test('hello =~ h[aeiou]llo') is True  # Character set
+        assert Conditional.test('hello =~ h[^aeiou]llo') is False  # Negated character set
+        assert Conditional.test('hello123 =~ h.*\\d+') is True  # Digits
+        assert Conditional.test('hello =~ ^h.*o$') is True  # Start and end of string
+
+        assert Conditional.test('hello !~ h.llo') is False
+        assert Conditional.test('hello !~ h.*o') is False
+        assert Conditional.test('hello !~ h[aeiou]llo') is False
+        assert Conditional.test('hello !~ h[^aeiou]llo') is True
+        assert Conditional.test('hello123 !~ h.*\\d+') is False
+        assert Conditional.test('hello !~ ^h.*o$') is False


### PR DESCRIPTION
This PR relates to issue #108 

- add support for regex in conditionals. 
   - match condition for r'^(.+?)\s*(=~|!~)\s*(.+?)$' and unpack match in string, operator and pattern
   - perform re.search in regex_handler function

- add unit test for regex conditionals
- update docs