### PR TITLE
refactor executors import and initialisation

### DIFF
--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -9,23 +9,25 @@ configuration.
 """
 
 import logging
-from attackmate.executors.shell.shellexecutor import ShellExecutor
-from attackmate.executors.ssh.sshexecutor import SSHExecutor
-from attackmate.executors.metasploit.msfsessionexecutor import MsfSessionExecutor
-from attackmate.executors.metasploit.msfpayloadexecutor import MsfPayloadExecutor
-from attackmate.executors.metasploit.msfsessionstore import MsfSessionStore
-from attackmate.executors.metasploit.msfexecutor import MsfModuleExecutor
-from attackmate.executors.sliver.sliverexecutor import SliverExecutor
-from attackmate.executors.sliver.sliversessionexecutor import SliverSessionExecutor
-from attackmate.executors.father.fatherexecutor import FatherExecutor
-from attackmate.executors.http.webservexecutor import WebServExecutor
-from attackmate.executors.http.httpclientexecutor import HttpClientExecutor
-from attackmate.executors.common.setvarexecutor import SetVarExecutor
-from attackmate.executors.common.sleepexecutor import SleepExecutor
-from attackmate.executors.common.tempfileexecutor import TempfileExecutor
-from attackmate.executors.common.debugexecutor import DebugExecutor
-from attackmate.executors.common.includeexecutor import IncludeExecutor
-from attackmate.executors.common.regexexecutor import RegExExecutor
+from attackmate.executors import (
+    ShellExecutor,
+    SSHExecutor,
+    MsfSessionExecutor,
+    MsfPayloadExecutor,
+    MsfSessionStore,
+    MsfModuleExecutor,
+    SliverExecutor,
+    SliverSessionExecutor,
+    FatherExecutor,
+    WebServExecutor,
+    HttpClientExecutor,
+    SetVarExecutor,
+    SleepExecutor,
+    TempfileExecutor,
+    DebugExecutor,
+    IncludeExecutor,
+    RegExExecutor,
+)
 from attackmate.schemas.config import Config
 from attackmate.schemas.playbook import Playbook, Commands
 from .variablestore import VariableStore
@@ -34,7 +36,7 @@ from .processmanager import ProcessManager
 
 class AttackMate:
     def __init__(self, playbook: Playbook, config: Config) -> None:
-        """ Constructor for AttackMate
+        """Constructor for AttackMate
 
         This constructor initializes the logger('playbook'), the playbook,
         the variable-parser and all the executors.
@@ -52,7 +54,7 @@ class AttackMate:
         self.initialize_executors()
 
     def initialize_variable_parser(self):
-        """ Initializes the variable-parser
+        """Initializes the variable-parser
 
         The variablestore stores and replaces variables with values in certain strings
         """
@@ -60,94 +62,61 @@ class AttackMate:
         self.varstore.from_dict(self.playbook.vars)
 
     def initialize_executors(self):
-        """ Initialize all Executors
+        """Initialize all Executors
 
         Executors are supposed to execute commands. This method initializes
         all possible executors.
 
         """
         self.msfsessionstore = MsfSessionStore(self.varstore)
-        self.se = ShellExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.sleep = SleepExecutor(self.pm, self.pyconfig.cmd_config,
-                                   varstore=self.varstore)
-        self.ssh = SSHExecutor(self.pm, self.pyconfig.cmd_config,
-                               varstore=self.varstore)
-        self.father = FatherExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.msfmodule = MsfModuleExecutor(self.pm, self.pyconfig.cmd_config,
-                                           varstore=self.varstore,
-                                           msfconfig=self.pyconfig.msf_config,
-                                           msfsessionstore=self.msfsessionstore)
-        self.msfpayload = MsfPayloadExecutor(self.pm, self.varstore,
-                                             self.pyconfig.cmd_config,
-                                             msfconfig=self.pyconfig.msf_config)
-        self.msfsession = MsfSessionExecutor(
+        executor_classes = {
+            'shell': ShellExecutor,
+            'sleep': SleepExecutor,
+            'ssh': SSHExecutor,
+            'father': FatherExecutor,
+            'msf-module': MsfModuleExecutor,
+            'msf-payload': MsfPayloadExecutor,
+            'msf-session': MsfSessionExecutor,
+            'debug': DebugExecutor,
+            'webserv': WebServExecutor,
+            'setvar': SetVarExecutor,
+            'regex': RegExExecutor,
+            'sliver': SliverExecutor,
+            'sliver-session': SliverSessionExecutor,
+            'mktemp': TempfileExecutor,
+            'include': IncludeExecutor,
+            'http-client': HttpClientExecutor,
+        }
+        self.executors = {
+            key: cls(
                 self.pm,
                 self.pyconfig.cmd_config,
                 varstore=self.varstore,
-                msfconfig=self.pyconfig.msf_config,
-                msfsessionstore=self.msfsessionstore)
-        self.debugger = DebugExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.webserv = WebServExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.setvar = SetVarExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.mktemp = TempfileExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.regex = RegExExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.httpclient = HttpClientExecutor(self.pm, self.varstore, self.pyconfig.cmd_config)
-        self.include = IncludeExecutor(self.pm, self.pyconfig.cmd_config,
-                                       varstore=self.varstore,
-                                       runfunc=self.run_commands)
-        self.sliver = SliverExecutor(self.pm, self.pyconfig.cmd_config,
-                                     varstore=self.varstore,
-                                     sliver_config=self.pyconfig.sliver_config)
-        self.sliversession = SliverSessionExecutor(self.pm, self.pyconfig.cmd_config,
-                                                   varstore=self.varstore,
-                                                   sliver_config=self.pyconfig.sliver_config)
+                msfconfig=self.pyconfig.msf_config if 'msf' in key else None,
+                msfsessionstore=self.msfsessionstore if key == 'msf-session' else None,
+                sliver_config=self.pyconfig.sliver_config if 'sliver' in key else None,
+                runfunc=self.run_commands if key == 'include' else None,
+            )
+            for key, cls in executor_classes.items()
+        }
 
     def run_commands(self, commands: Commands):
-        """ Pass commands to the executors
+        """Pass commands to the executors
 
         This function interates over all configured
         commands and passes them to the executors.
 
         """
         for command in commands:
-            if command.type == 'shell':
-                self.se.run(command)
-            if command.type == 'father':
-                self.father.run(command)
-            if command.type == 'sleep':
-                self.sleep.run(command)
-            if command.type == 'msf-module':
-                self.msfmodule.run(command)
-            if command.type == 'msf-session':
-                self.msfsession.run(command)
-            if command.type == 'msf-payload':
-                self.msfpayload.run(command)
-            if command.type in ['ssh', 'sftp']:
-                self.ssh.run(command)
-            if command.type == 'debug':
-                self.debugger.run(command)
-            if command.type == 'setvar':
-                self.setvar.run(command)
-            if command.type == 'regex':
-                self.regex.run(command)
-            if command.type == 'sliver':
-                self.sliver.run(command)
-            if command.type == 'sliver-session':
-                self.sliversession.run(command)
-            if command.type == 'mktemp':
-                self.mktemp.run(command)
-            if command.type == 'include':
-                self.include.run(command)
-            if command.type == 'webserv':
-                self.webserv.run(command)
-            if command.type == 'http-client':
-                self.httpclient.run(command)
+            executor = self.executors.get(command.type)
+            if executor:
+                executor.run(command)
 
     def main(self):
-        """ The main function
+        """The main function
 
-            Passes the main playbook-commands
-            to run_commands
+        Passes the main playbook-commands
+        to run_commands
 
         """
         try:

--- a/src/attackmate/executors/__init__.py
+++ b/src/attackmate/executors/__init__.py
@@ -1,0 +1,38 @@
+from .shell.shellexecutor import ShellExecutor
+from .ssh.sshexecutor import SSHExecutor
+from .metasploit.msfsessionexecutor import MsfSessionExecutor
+from .metasploit.msfpayloadexecutor import MsfPayloadExecutor
+from .metasploit.msfsessionstore import MsfSessionStore
+from .metasploit.msfexecutor import MsfModuleExecutor
+from .sliver.sliverexecutor import SliverExecutor
+from .sliver.sliversessionexecutor import SliverSessionExecutor
+from .father.fatherexecutor import FatherExecutor
+from .http.webservexecutor import WebServExecutor
+from .http.httpclientexecutor import HttpClientExecutor
+from .common.setvarexecutor import SetVarExecutor
+from .common.sleepexecutor import SleepExecutor
+from .common.tempfileexecutor import TempfileExecutor
+from .common.debugexecutor import DebugExecutor
+from .common.includeexecutor import IncludeExecutor
+from .common.regexexecutor import RegExExecutor
+
+
+__all__ = [
+    'ShellExecutor',
+    'SSHExecutor',
+    'MsfSessionExecutor',
+    'MsfPayloadExecutor',
+    'MsfSessionStore',
+    'MsfModuleExecutor',
+    'SliverExecutor',
+    'SliverSessionExecutor',
+    'FatherExecutor',
+    'WebServExecutor',
+    'HttpClientExecutor',
+    'SetVarExecutor',
+    'SleepExecutor',
+    'TempfileExecutor',
+    'DebugExecutor',
+    'IncludeExecutor',
+    'RegExExecutor',
+]

--- a/src/attackmate/executors/baseexecutor.py
+++ b/src/attackmate/executors/baseexecutor.py
@@ -27,7 +27,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
 
     """
 
-    def __init__(self, pm: ProcessManager, variablestore: VariableStore, cmdconfig=CommandConfig()):
+    def __init__(self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig()):
         """Constructor for BaseExecutor
 
         Parameters
@@ -37,7 +37,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
 
         """
         Background.__init__(self, pm)
-        CmdVars.__init__(self, variablestore)
+        CmdVars.__init__(self, varstore)
         ExitOnError.__init__(self)
         Looper.__init__(self, cmdconfig)
         self.logger = logging.getLogger('playbook')


### PR DESCRIPTION
This PR relates to issue #104 

 - Add new executor class file __init__. py in the attackmate/executors directory
 - Modify the AttackMate class to streamline import of all executors from attackmate.executors
 - map command types to their respective executor classes in dictionary self.executors
 - pass common named initialization arguments as dictionary when initializing executors
 - use dictionary comprehension to run executors based on the command type

Instructions to add new executor:

Create a new class file for the executor in the appropriate subdirectory of `attackmate/executors`. Update the `__init__.py` file to import the new executor and add it to the module API. Integrate the new executor into the `AttackMate `class by adding it to the `self.executor` dictionary of the `initialize_executors function()`. Document the new executor by creating a .rst file in the `docs/executors` directory. Update the documentation index to include the new executor’s documentation.
