### PR TITLE
sftp command

### DIFF
--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -60,6 +60,7 @@ class AttackMate:
         self.executors = {
             'shell': executors.ShellExecutor(**init_args),
             'ssh': executors.SSHExecutor(**init_args),
+            'sftp': executors.SSHExecutor(**init_args),
             'msf-session': executors.MsfSessionExecutor(
                 **init_args, msfconfig=self.pyconfig.msf_config, msfsessionstore=self.msfsessionstore
             ),

--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -57,10 +57,13 @@ class AttackMate:
             'cmdconfig': self.pyconfig.cmd_config,
         }
 
+        # same executor instance for ssh and sftp commands
+        ssh_executor = executors.SSHExecutor(**init_args)
+
         self.executors = {
             'shell': executors.ShellExecutor(**init_args),
-            'ssh': executors.SSHExecutor(**init_args),
-            'sftp': executors.SSHExecutor(**init_args),
+            'ssh': ssh_executor,
+            'sftp': ssh_executor,
             'msf-session': executors.MsfSessionExecutor(
                 **init_args, msfconfig=self.pyconfig.msf_config, msfsessionstore=self.msfsessionstore
             ),

--- a/src/attackmate/executors/ssh/sftpfeature.py
+++ b/src/attackmate/executors/ssh/sftpfeature.py
@@ -1,16 +1,24 @@
 import os
+from attackmate.execexception import ExecException
 from attackmate.schemas.ssh import SFTPCommand
 from paramiko.client import SSHClient
 
 
-class SFTPFeature():
+class SFTPFeature:
     def exec_sftp(self, client: SSHClient, command: SFTPCommand) -> str:
         output = ''
         if command.cmd == 'put':
-            client.open_sftp().put(command.local_path, command.remote_path)
-            output = f'Uploaded to {command.remote_path}'
-            if command.mode:
-                client.open_sftp().chmod(command.remote_path, int(command.mode, 8))
+            try:
+                client.open_sftp().put(command.local_path, command.remote_path)
+                output = f'Uploaded to {command.remote_path}'
+                if command.mode:
+                    client.open_sftp().chmod(command.remote_path, int(command.mode, 8))
+            except IOError as e:
+                raise ExecException(
+                    f'Could not upload to {command.remote_path}. '
+                    f'Ensure that the destination path specifies a filename. '
+                    f'Original IOError: {e}'
+                )
         elif command.cmd == 'get':
             client.open_sftp().get(command.remote_path, command.local_path)
             output = f'Downloaded from {command.remote_path}'

--- a/src/attackmate/executors/ssh/sshexecutor.py
+++ b/src/attackmate/executors/ssh/sshexecutor.py
@@ -120,7 +120,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             self.session_store.set_session(command.creates_session, client)
         return client
 
-    def _exec_cmd(self, command: SSHCommand) -> Result:
+    def _exec_cmd(self, command) -> Result:
         error = None
         output = ''
 

--- a/src/attackmate/executors/ssh/sshexecutor.py
+++ b/src/attackmate/executors/ssh/sshexecutor.py
@@ -38,7 +38,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
         self.jmp_port = 22
         self.jmp_username = self.username
 
-    def cache_settings(self, command: SSHCommand):
+    def cache_settings(self, command: SFTPCommand | SSHCommand):
         if command.hostname:
             self.hostname = command.hostname
         if command.port:
@@ -64,7 +64,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
         self.cache_settings(command)
         self.logger.info(f"Executing SSH-Command: '{command.cmd}'")
 
-    def connect_jmphost(self, command: SSHCommand):
+    def connect_jmphost(self, command: SFTPCommand | SSHCommand):
         jmp = SSHClient()
         jmp.load_system_host_keys()
         jmp.set_missing_host_key_policy(AutoAddPolicy())
@@ -87,7 +87,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             raise ExecException(f'Could not get transport of SSH-Jumphost {self.jmp_hostname}')
         return sock
 
-    def connect_use_session(self, command: SSHCommand) -> SSHClient:
+    def connect_use_session(self, command: SFTPCommand | SSHCommand) -> SSHClient:
         if command.session is not None:
             if not self.session_store.has_session(command.session):
                 raise ExecException(f'SSH-Session not in Session-Store: {command.session}')
@@ -120,7 +120,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             self.session_store.set_session(command.creates_session, client)
         return client
 
-    def _exec_cmd(self, command) -> Result:
+    def _exec_cmd(self, command: SFTPCommand | SSHCommand) -> Result:
         error = None
         output = ''
 


### PR DESCRIPTION
This PR relates to issue #117 and issue #119

- add missing sftp command to executors (using same instance for ssh and sftp commands)
- use union of SSHCommand and SFTPCommand for proper type hinting
- use same instance of SSHExecutor for ssh and stfp commands
- throw ExecExeption with informative message if sftp put fails with IOError (happens when the destination path does not specify a filename)
now: 
![image](https://github.com/user-attachments/assets/c62acfad-6698-43e3-9f63-e95b112b091b)


before:
![image](https://github.com/user-attachments/assets/3e3ce5de-a92e-4d98-94e3-453e889d87c7)


