### PR TITLE
executor factory

### DIFF
--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -56,6 +56,7 @@ class AttackMate:
             'msfconfig': self.pyconfig.msf_config,
             'msfsessionstore': self.msfsessionstore,
             'sliver_config': self.pyconfig.sliver_config,
+            'runfunc': self._run_commands,
         }
         return config
 

--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -35,12 +35,12 @@ class AttackMate:
         self.pm = ProcessManager()
         self.pyconfig = config
         self.playbook = playbook
-        self.initialize_variable_parser()
+        self._initialize_variable_parser()
         self.msfsessionstore = executors.MsfSessionStore(self.varstore)
-        self.executor_config = self.get_executor_config()
+        self.executor_config = self._get_executor_config()
         self.executors: Dict[str, BaseExecutor] = {}
 
-    def initialize_variable_parser(self):
+    def _initialize_variable_parser(self):
         """Initializes the variable-parser
 
         The variablestore stores and replaces variables with values in certain strings
@@ -48,7 +48,7 @@ class AttackMate:
         self.varstore = VariableStore()
         self.varstore.from_dict(self.playbook.vars)
 
-    def get_executor_config(self) -> dict:
+    def _get_executor_config(self) -> dict:
         config = {
             'pm': self.pm,
             'varstore': self.varstore,
@@ -59,7 +59,7 @@ class AttackMate:
         }
         return config
 
-    def get_executor(self, command_type: str) -> BaseExecutor:
+    def _get_executor(self, command_type: str) -> BaseExecutor:
         if command_type not in self.executors:
             self.executors[command_type] = executor_factory.create_executor(
                 command_type, **self.executor_config
@@ -67,12 +67,10 @@ class AttackMate:
 
         return self.executors[command_type]
 
-    def run_commands(self, commands: Commands):
+    def _run_commands(self, commands: Commands):
         for command in commands:
-            if command.type == 'sftp':
-                executor = self.get_executor('ssh')
-            else:
-                executor = self.get_executor(command.type)
+            command_type = 'ssh' if command.type == 'sftp' else command.type
+            executor = self._get_executor(command_type)
             if executor:
                 executor.run(command)
 
@@ -84,7 +82,7 @@ class AttackMate:
 
         """
         try:
-            self.run_commands(self.playbook.commands)
+            self._run_commands(self.playbook.commands)
             self.pm.kill_or_wait_processes()
         except KeyboardInterrupt:
             self.logger.warn('Program stopped manually')

--- a/src/attackmate/executors/common/debugexecutor.py
+++ b/src/attackmate/executors/common/debugexecutor.py
@@ -7,8 +7,10 @@ This class allows to print out variables.
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.result import Result
 from attackmate.schemas.debug import DebugCommand
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('debug')
 class DebugExecutor(BaseExecutor):
 
     def log_command(self, command: DebugCommand):

--- a/src/attackmate/executors/common/includeexecutor.py
+++ b/src/attackmate/executors/common/includeexecutor.py
@@ -13,8 +13,10 @@ from attackmate.schemas.playbook import Playbook, Commands
 from attackmate.variablestore import VariableStore
 from attackmate.execexception import ExecException
 from attackmate.processmanager import ProcessManager
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('include')
 class IncludeExecutor(BaseExecutor):
     def __init__(
         self,

--- a/src/attackmate/executors/common/regexexecutor.py
+++ b/src/attackmate/executors/common/regexexecutor.py
@@ -11,8 +11,10 @@ from attackmate.schemas.regex import RegExCommand
 from string import Template
 from typing import Match
 import re
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('regex')
 class RegExExecutor(BaseExecutor):
 
     def log_command(self, command: RegExCommand):

--- a/src/attackmate/executors/common/setvarexecutor.py
+++ b/src/attackmate/executors/common/setvarexecutor.py
@@ -10,8 +10,10 @@ from attackmate.schemas.setvar import SetVarCommand
 import base64
 import codecs
 import urllib.parse
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('setvar')
 class SetVarExecutor(BaseExecutor):
     def encode(self, encoder: str, cmd: str):
         if encoder == 'base64-encoder':

--- a/src/attackmate/executors/common/sleepexecutor.py
+++ b/src/attackmate/executors/common/sleepexecutor.py
@@ -5,8 +5,10 @@ from attackmate.result import Result
 from attackmate.executors.features.cmdvars import CmdVars
 from attackmate.variablestore import VariableStore
 from attackmate.processmanager import ProcessManager
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('sleep')
 class SleepExecutor(BaseExecutor):
     def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore):
         super().__init__(pm, varstore, cmdconfig)

--- a/src/attackmate/executors/common/tempfileexecutor.py
+++ b/src/attackmate/executors/common/tempfileexecutor.py
@@ -11,8 +11,10 @@ from attackmate.result import Result
 from attackmate.schemas.tempfile import TempfileCommand
 from attackmate.variablestore import VariableStore
 from attackmate.processmanager import ProcessManager
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('mktemp')
 class TempfileExecutor(BaseExecutor):
     def __init__(self, pm: ProcessManager, varstore: VariableStore, cmdconfig=None):
         self.tempfilestore: dict[str, Any] = {}

--- a/src/attackmate/executors/executor_factory.py
+++ b/src/attackmate/executors/executor_factory.py
@@ -1,0 +1,29 @@
+from typing import Type
+from attackmate.executors.baseexecutor import BaseExecutor
+import inspect
+
+
+class ExecutorFactory:
+    def __init__(self):
+        self._executors = {}
+
+    def register_executor(self, command_type: str):
+        def decorator(cls: Type[BaseExecutor]):
+            self._executors[command_type] = cls
+            return cls
+
+        return decorator
+
+    def create_executor(self, command_type: str, **kwargs) -> BaseExecutor:
+        executor_cls = self._executors.get(command_type)
+        if not executor_cls:
+            raise ValueError(f'Executor not found for command type: {command_type}')
+
+        # Filter kwargs to match the executor's __init__ signature
+        init_signature = inspect.signature(executor_cls.__init__)
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k in init_signature.parameters}
+
+        return executor_cls(**filtered_kwargs)
+
+
+executor_factory = ExecutorFactory()

--- a/src/attackmate/executors/father/fatherexecutor.py
+++ b/src/attackmate/executors/father/fatherexecutor.py
@@ -18,7 +18,10 @@ from attackmate.schemas.father import FatherCommand
 from attackmate.variablestore import VariableStore
 from attackmate.processmanager import ProcessManager
 
+from attackmate.executors.executor_factory import executor_factory
 
+
+@executor_factory.register_executor('father')
 class FatherExecutor(BaseExecutor):
     def __init__(self, pm: ProcessManager, varstore: VariableStore, cmdconfig=None):
         self.tempfilestore: list[Any] = []

--- a/src/attackmate/executors/http/httpclientexecutor.py
+++ b/src/attackmate/executors/http/httpclientexecutor.py
@@ -10,8 +10,10 @@ from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.result import Result
 from attackmate.schemas.http import HttpClientCommand
 from attackmate.execexception import ExecException
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('http-client')
 class HttpClientExecutor(BaseExecutor):
     def log_command(self, command: HttpClientCommand):
         self.logger.info(f'Performing HTTP[{command.cmd}] to {command.url}')

--- a/src/attackmate/executors/http/webservexecutor.py
+++ b/src/attackmate/executors/http/webservexecutor.py
@@ -11,8 +11,10 @@ from attackmate.schemas.http import WebServCommand
 from attackmate.executors.features.cmdvars import CmdVars
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import magic
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('webserv')
 class WebRequestHandler(BaseHTTPRequestHandler):
     def __init__(self, *args, local_path=None, **kwargs):
         self.local_path = local_path

--- a/src/attackmate/executors/http/webservexecutor.py
+++ b/src/attackmate/executors/http/webservexecutor.py
@@ -14,7 +14,6 @@ import magic
 from attackmate.executors.executor_factory import executor_factory
 
 
-@executor_factory.register_executor('webserv')
 class WebRequestHandler(BaseHTTPRequestHandler):
     def __init__(self, *args, local_path=None, **kwargs):
         self.local_path = local_path
@@ -52,6 +51,7 @@ class WebServe(HTTPServer):
             pass
 
 
+@executor_factory.register_executor('webserv')
 class WebServExecutor(BaseExecutor):
 
     def log_command(self, command: WebServCommand):

--- a/src/attackmate/executors/metasploit/msfexecutor.py
+++ b/src/attackmate/executors/metasploit/msfexecutor.py
@@ -12,8 +12,10 @@ from attackmate.executors.metasploit.msfsessionstore import MsfSessionStore
 from attackmate.processmanager import ProcessManager
 from multiprocessing import Manager
 from multiprocessing.queues import JoinableQueue
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('msf-module')
 class MsfModuleExecutor(BaseExecutor):
     def __init__(
         self,

--- a/src/attackmate/executors/metasploit/msfpayloadexecutor.py
+++ b/src/attackmate/executors/metasploit/msfpayloadexecutor.py
@@ -16,8 +16,10 @@ from attackmate.variablestore import VariableStore
 from attackmate.executors.features.cmdvars import CmdVars
 from attackmate.schemas.metasploit import MsfPayloadCommand
 from attackmate.schemas.config import CommandConfig
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('msf-payload')
 class MsfPayloadExecutor(BaseExecutor):
     def __init__(
         self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig(), *, msfconfig=None

--- a/src/attackmate/executors/metasploit/msfsessionexecutor.py
+++ b/src/attackmate/executors/metasploit/msfsessionexecutor.py
@@ -9,8 +9,10 @@ from attackmate.result import Result
 from attackmate.schemas.base import BaseCommand
 from attackmate.schemas.metasploit import MsfSessionCommand
 from attackmate.processmanager import ProcessManager
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('msf-session')
 class MsfSessionExecutor(BaseExecutor):
     def __init__(
         self,

--- a/src/attackmate/executors/shell/shellexecutor.py
+++ b/src/attackmate/executors/shell/shellexecutor.py
@@ -20,8 +20,10 @@ from attackmate.variablestore import VariableStore
 from attackmate.processmanager import ProcessManager
 from attackmate.executors.shell.sessionstore import SessionStore
 from attackmate.executors.features.cmdvars import CmdVars
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('shell')
 class ShellExecutor(BaseExecutor):
     def __init__(self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig()):
         self.session_store = SessionStore()

--- a/src/attackmate/executors/sliver/sliverexecutor.py
+++ b/src/attackmate/executors/sliver/sliverexecutor.py
@@ -19,7 +19,10 @@ from attackmate.schemas.base import BaseCommand
 from attackmate.schemas.sliver import SliverGenerateCommand, SliverHttpsListenerCommand
 from attackmate.processmanager import ProcessManager
 
+from attackmate.executors.executor_factory import executor_factory
 
+
+@executor_factory.register_executor('sliver')
 class SliverExecutor(BaseExecutor):
 
     def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore, sliver_config=None):

--- a/src/attackmate/executors/sliver/sliversessionexecutor.py
+++ b/src/attackmate/executors/sliver/sliversessionexecutor.py
@@ -35,8 +35,10 @@ from datetime import datetime, timedelta
 from tabulate import tabulate
 from attackmate.executors.features.cmdvars import CmdVars
 from attackmate.processmanager import ProcessManager
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('sliver-session')
 class SliverSessionExecutor(BaseExecutor):
 
     def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore, sliver_config=None):

--- a/src/attackmate/executors/ssh/sshexecutor.py
+++ b/src/attackmate/executors/ssh/sshexecutor.py
@@ -18,8 +18,10 @@ from attackmate.variablestore import VariableStore
 from attackmate.processmanager import ProcessManager
 from attackmate.executors.ssh.sessionstore import SessionStore
 from attackmate.executors.ssh.sftpfeature import SFTPFeature
+from attackmate.executors.executor_factory import executor_factory
 
 
+@executor_factory.register_executor('ssh')
 class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
     def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore):
         self.session_store = SessionStore()


### PR DESCRIPTION
relates to #104 

- adds an ExecutorFactory Class
- add docs

The `ExecutorFactory `class manages and creates executor instances based on a command type. It maintains a registry (_executors) mapping command type strings to executor classes. Executors are registered using the `register_executor `method, which provides a decorator to associate a command type with a class. The `create_executor `method retrieves the appropriate class for a given command type and filters arguments to match the class's constructor signature before creating an instance. 


- This makes extension/developing new features easier. To add a new executor to Attackmate: 
1) `import from attackmate.executors.executor_factory import executor_factory ` 
2) register/decorate the new executor class with the command type `@executor_factory.register_executor('debug')` 
3) if the new class requires any new init arguments, these have to be added to the `_get_executor_config` in attackmate.py. 
 --> All configs are always passed to the executor factory, which filters for the class __init__ signature and only uses the configs that are needed.