### PR TITLE
replace prefixed env vars

### DIFF
--- a/docs/source/playbook/vars.rst
+++ b/docs/source/playbook/vars.rst
@@ -9,9 +9,9 @@ Once assigned, they can be used as placeholders in command-settings. It
 is unnecessary to begin variable names with a $-sign when defined in the
 vars-section. However, when variables are placed in the commands section,
 they always must start with a $-sign.
-If the same variable name with the prefix "ATTACKMATE_" exists as an 
+If the same variable name with the prefix "ATTACKMATE_" exists as an
 environment variable it will overwrite the playbook variable value.
-i.e. the playbookvariabel $FOO will be overwritten be environment variabel 
+i.e. the playbookvariabel $FOO will be overwritten be environment variabel
 $ATTACKMATE_FOO.
 
 .. code-block:: yaml

--- a/docs/source/playbook/vars.rst
+++ b/docs/source/playbook/vars.rst
@@ -9,6 +9,10 @@ Once assigned, they can be used as placeholders in command-settings. It
 is unnecessary to begin variable names with a $-sign when defined in the
 vars-section. However, when variables are placed in the commands section,
 they always must start with a $-sign.
+If the same variable name with the prefix "ATTACKMATE_" exists as an 
+environment variable it will overwrite the playbook variable value.
+i.e. the playbookvariabel $FOO will be overwritten be environment variabel 
+$ATTACKMATE_FOO.
 
 .. code-block:: yaml
 

--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -42,6 +42,7 @@ class AttackMate:
         """
         self.varstore = VariableStore()
         self.varstore.from_dict(self.playbook.vars)
+        self.varstore.replace_with_prefixed_env_vars()
 
     def initialize_executors(self):
         """Initialize all Executors

--- a/src/attackmate/variablestore.py
+++ b/src/attackmate/variablestore.py
@@ -1,23 +1,26 @@
 from string import Template
 import re
+import os
 from typing import Any, Optional
 
 
 class ListParseException(Exception):
-    """ Exception for all List-Parser
+    """Exception for all List-Parser
 
     This exception is raised by parse_list if anything
     goes wrong.
     """
+
     pass
 
 
 class VariableNotFound(Exception):
-    """ Exception for all List-Parser
+    """Exception for all List-Parser
 
     This exception is raised by get_variable if the
     variable does not exist in the variablestore.
     """
+
     pass
 
 
@@ -108,7 +111,7 @@ class VariableStore:
             if isinstance(value, list):
                 self.lists[varname] = list(value)
 
-    def get_variable(self, variable: str) -> (str | list[str]):
+    def get_variable(self, variable: str) -> str | list[str]:
         if variable in self.variables:
             return self.variables[variable]
         if variable in self.lists:
@@ -120,3 +123,15 @@ class VariableStore:
             return self.substitute_str(data, blank)
         else:
             return data
+
+    def get_prefixed_env_vars(self, prefix: str = "ATTACKMATE_") -> dict[str, str]:
+        prefixed_env_vars = {k[len(prefix) :]: v for k, v in os.environ.items() if k.startswith(prefix)}
+        return prefixed_env_vars
+
+    def replace_with_prefixed_env_vars(self):
+        """Replaces the current variables with corresponding prefixed environment variables if they exist."""
+        env_vars = self.get_prefixed_env_vars()
+
+        for var_name in list(self.variables.keys()):
+            if var_name in env_vars:
+                self.set_variable(var_name, env_vars[var_name])

--- a/test/units/test_variablestore.py
+++ b/test/units/test_variablestore.py
@@ -1,5 +1,7 @@
 from attackmate.variablestore import VariableNotFound, VariableStore, ListParseException
 import unittest
+import os
+from unittest.mock import patch
 
 
 class TestVariableStore(unittest.TestCase):
@@ -100,3 +102,32 @@ class TestVariableStore(unittest.TestCase):
         assert all_list_vars['second[0]'] == 'one'
         assert all_list_vars['second[1]'] == 'two'
         assert all_list_vars['second[2]'] == 'three'
+
+    def test_get_prefixed_env_vars(self) -> None:
+        var_store: VariableStore = VariableStore()
+        env_vars = {
+            'ATTACKMATE_FOO': 'env_foo',
+            'ATTACKMATE_BAR': 'env_bar',
+        }
+        with patch.dict(os.environ, env_vars):
+            prefixed_env_vars = var_store.get_prefixed_env_vars()
+            assert len(prefixed_env_vars) == 2
+            assert prefixed_env_vars['FOO'] == 'env_foo'
+            assert prefixed_env_vars['BAR'] == 'env_bar'
+
+    def test_replace_with_prefixed_env_vars(self) -> None:
+        var_store: VariableStore = VariableStore()
+        store_vars = {
+            'FOO': 'store_foo',
+            'BAR': 'store_bar',
+        }
+        env_vars = {
+            'ATTACKMATE_FOO': 'env_foo',
+            'ATTACKMATE_BAR': 'env_bar',
+        }
+        var_store.from_dict(store_vars)
+        with patch.dict(os.environ, env_vars):
+            var_store.replace_with_prefixed_env_vars()
+            assert len(var_store.variables) == 2
+            assert var_store.variables['FOO'] == 'env_foo'
+            assert var_store.variables['BAR'] == 'env_bar'


### PR DESCRIPTION
This PR relates to issue #60 
- adds a function to the variable store to overwrite variables in the variable store if the same environment variable with a certain prefix
exists ( default "ATTACKMATE_")
Example:
![Screenshot from 2024-09-11 10-33-14](https://github.com/user-attachments/assets/094990df-1424-4d37-b59a-ff88a7ebdef3)
![Screenshot from 2024-09-11 10-33-06](https://github.com/user-attachments/assets/fc67e998-e19c-4dd9-8215-45b9dc906d43)

- unittests
- update docs