### PR TITLE
Fix json logger

### DIFF
--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -110,6 +110,6 @@ class AttackMate:
             self.run_commands(self.playbook.commands)
             self.pm.kill_or_wait_processes()
         except KeyboardInterrupt:
-            self.logger.warn('Program stopped manually')
+            self.logger.warning('Program stopped manually')
 
         return 0

--- a/src/attackmate/executors/baseexecutor.py
+++ b/src/attackmate/executors/baseexecutor.py
@@ -65,9 +65,9 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
         if command.only_if:
             if not Conditional.test(self.varstore.substitute(command.only_if, True)):
                 if hasattr(command, 'type'):
-                    self.logger.warn(f'Skipping {command.type}: {command.cmd}')
+                    self.logger.warning(f'Skipping {command.type}: {command.cmd}')
                 else:
-                    self.logger.warn(f'Skipping {command.cmd}')
+                    self.logger.warning(f'Skipping {command.cmd}')
                 return
         self.reset_run_count()
         self.logger.debug(f"Template-Command: '{command.cmd}'")
@@ -86,16 +86,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
             logger.info(f'Metadata: {json.dumps(command.metadata)}')
 
     def log_json(self, logger: logging.Logger, command, time):
-        command_dict = OrderedDict()
-        command_dict['start-datetime'] = time
-        if hasattr(command, 'type'):
-            command_dict['type'] = command.type
-        command_dict['cmd'] = command.cmd
-
-        command_dict['parameters'] = dict()
-        for key, value in command.__dict__.items():
-            if key not in command_dict:
-                command_dict['parameters'][key] = value
+        command_dict = self.make_command_serilizable(command, time)
 
         try:
             logger.info(json.dumps(command_dict))
@@ -107,6 +98,25 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
                 e,
             )
 
+    def make_command_serilizable(self, command, time):
+        command_dict = OrderedDict()
+        command_dict['start-datetime'] = time
+        if hasattr(command, 'type'):
+            command_dict['type'] = command.type
+        command_dict['cmd'] = command.cmd
+
+        command_dict['parameters'] = dict()
+        for key, value in command.__dict__.items():
+            if key not in command_dict and key != 'commands':
+                command_dict['parameters'][key] = value
+            # Handle nested "commands" recursively
+            if key == 'commands' and isinstance(value, list):
+                command_dict['parameters']['commands'] = [
+                    self.make_command_serilizable(sub_command, time) for sub_command in value
+                ]
+
+        return command_dict
+
     def save_output(self, command: BaseCommand, result: Result):
         """Save output of command to a file. This method will
         ignore all exceptions and won't stop the programm
@@ -117,7 +127,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
                 with open(command.save, 'w') as outfile:
                     outfile.write(result.stdout)
             except Exception as e:
-                self.logger.warn(f'Unable to write output to file {command.save}: {e}')
+                self.logger.warning(f'Unable to write output to file {command.save}: {e}')
 
     def exec(self, command: BaseCommand):
         try:

--- a/src/attackmate/executors/baseexecutor.py
+++ b/src/attackmate/executors/baseexecutor.py
@@ -99,8 +99,13 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
 
         try:
             logger.info(json.dumps(command_dict))
-        except TypeError:
-            logger.warn('log_json is broken')
+        except TypeError as e:
+            logger.warning(
+                'Failed to serialize object to JSON. '
+                'Ensure only basic data types (str, int, float, bool, list, dict) are used. '
+                'Error details: %s',
+                e,
+            )
 
     def save_output(self, command: BaseCommand, result: Result):
         """Save output of command to a file. This method will

--- a/src/attackmate/executors/baseexecutor.py
+++ b/src/attackmate/executors/baseexecutor.py
@@ -86,7 +86,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
             logger.info(f'Metadata: {json.dumps(command.metadata)}')
 
     def log_json(self, logger: logging.Logger, command, time):
-        command_dict = self.make_command_serilizable(command, time)
+        command_dict = self.make_command_serializable(command, time)
 
         try:
             logger.info(json.dumps(command_dict))
@@ -98,7 +98,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
                 e,
             )
 
-    def make_command_serilizable(self, command, time):
+    def make_command_serializable(self, command, time):
         command_dict = OrderedDict()
         command_dict['start-datetime'] = time
         if hasattr(command, 'type'):

--- a/src/attackmate/executors/baseexecutor.py
+++ b/src/attackmate/executors/baseexecutor.py
@@ -112,7 +112,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
             # Handle nested "commands" recursively
             if key == 'commands' and isinstance(value, list):
                 command_dict['parameters']['commands'] = [
-                    self.make_command_serilizable(sub_command, time) for sub_command in value
+                    self.make_command_serializable(sub_command, time) for sub_command in value
                 ]
 
         return command_dict

--- a/src/attackmate/executors/common/debugexecutor.py
+++ b/src/attackmate/executors/common/debugexecutor.py
@@ -12,9 +12,9 @@ from attackmate.schemas.debug import DebugCommand
 class DebugExecutor(BaseExecutor):
 
     def log_command(self, command: DebugCommand):
-        self.logger.warn(f"Debug: '{command.cmd}'")
+        self.logger.warning(f"Debug: '{command.cmd}'")
         if command.varstore:
-            self.logger.warn(self.varstore.variables)
+            self.logger.warning(self.varstore.variables)
 
     def _exec_cmd(self, command: DebugCommand) -> Result:
         self.setoutuptvars = False

--- a/src/attackmate/executors/common/regexexecutor.py
+++ b/src/attackmate/executors/common/regexexecutor.py
@@ -16,7 +16,7 @@ import re
 class RegExExecutor(BaseExecutor):
 
     def log_command(self, command: RegExCommand):
-        self.logger.warn(f"RegEx: '{command.cmd}', Mode: '{command.mode}'")
+        self.logger.warning(f"RegEx: '{command.cmd}', Mode: '{command.mode}'")
 
     def forge_variables(self, data, variable_name='MATCH'):
         result = {}

--- a/src/attackmate/executors/common/tempfileexecutor.py
+++ b/src/attackmate/executors/common/tempfileexecutor.py
@@ -20,9 +20,9 @@ class TempfileExecutor(BaseExecutor):
 
     def log_command(self, command: TempfileCommand):
         if command.cmd == 'dir':
-            self.logger.warn('Creating temporary directory..')
+            self.logger.warning('Creating temporary directory..')
         else:
-            self.logger.warn('Creating temporary file..')
+            self.logger.warning('Creating temporary file..')
 
     def _exec_cmd(self, command: TempfileCommand) -> Result:
         ret = 0

--- a/src/attackmate/executors/features/looper.py
+++ b/src/attackmate/executors/features/looper.py
@@ -28,15 +28,13 @@ class Looper:
         if command.loop_if is not None:
             m = re.search(command.loop_if, result.stdout, re.MULTILINE)
             if m is not None:
-                self.logger.warning(
-                        f'Re-run command because loop_if matches: {m.group(0)}'
-                        )
+                self.logger.warning(f'Re-run command because loop_if matches: {m.group(0)}')
                 if self.run_count < CmdVars.variable_to_int('loop_count', command.loop_count):
                     self.run_count = self.run_count + 1
                     time.sleep(self.cmdconfig.loop_sleep)
                     self._loop_exec(command)
                 else:
-                    self.logger.error('Exitting because loop_count exceeded')
+                    self.logger.error('Exiting because loop_count exceeded')
                     exit(1)
             else:
                 self.logger.debug('loop_if does not match')
@@ -45,9 +43,7 @@ class Looper:
         if command.loop_if_not is not None:
             m = re.search(command.loop_if_not, result.stdout, re.MULTILINE)
             if m is None:
-                self.logger.warning(
-                        'Re-run command because loop_if_not does not match'
-                        )
+                self.logger.warning('Re-run command because loop_if_not does not match')
                 if self.run_count < CmdVars.variable_to_int('loop_count', command.loop_count):
                     self.run_count = self.run_count + 1
                     time.sleep(self.cmdconfig.loop_sleep)

--- a/test/units/test_regexexecutor.py
+++ b/test/units/test_regexexecutor.py
@@ -15,7 +15,7 @@ class TestRegExExecutor:
     def test_log_command(self):
         command = RegExCommand(type='regex', cmd='test', mode='findall', output={})
         self.executor.log_command(command)
-        self.executor.logger.warn.assert_called_once_with("RegEx: 'test', Mode: 'findall'")
+        self.executor.logger.warning.assert_called_once_with("RegEx: 'test', Mode: 'findall'")
 
     def test_forge_variables(self):
 


### PR DESCRIPTION
This PR fixes the json logging broken in PR #125 
Reason: json.dumps only work with basic datatypes

- recursively makes commands serializable for json logging (the loop command contains a list of commands)
- adds informative error message to json logging
- replaces deprecated logger.warn with logger.warning throughout the project

example structure:
![image](https://github.com/user-attachments/assets/4b1408c6-9b56-4604-a7ba-8765f93fa24a)
![image](https://github.com/user-attachments/assets/d6a31ee3-8532-4a17-90ee-80f00cbc15cd)

The actual execution of the commands (+time) gets logged as well in separate entries


