### PR TITLE
134 end condition for loop command

### DIFF
--- a/docs/source/playbook/commands/loop.rst
+++ b/docs/source/playbook/commands/loop.rst
@@ -60,7 +60,7 @@ The current index/iteration of the loop is also accessible as the `$LOOP_INDEX` 
    - **range(0, 10)**: Iterate over a range from 0 to 9.
    - **until($PORT == 7)
 
-.. confval:: break_condition
+.. confval:: break_if
 
    If defined, this condition is checked before every command in the loop.
    If the condition evaluates to `True`, break out of the loop.

--- a/docs/source/playbook/commands/loop.rst
+++ b/docs/source/playbook/commands/loop.rst
@@ -43,7 +43,8 @@ This mode iterates over a range of integers. The current index is accessible as 
 
 **Loop until condition is fulfilled**
 This mode iterates indefinitely until the condition is fulfilled. (Checked before every command within the loop)
-The current index/iteration of the loop is also accessible as the `$LOOP_INDEX` variable
+Variables in cmd settings of an until loop command until($VAR1 == $VAR2) will be substituted from the variable store on every iteration of the loop.
+The current index/iteration of the loop is also accessible as the `$LOOP_INDEX` variable for the until() condition.
 
 .. confval:: cmd
 

--- a/docs/source/playbook/commands/loop.rst
+++ b/docs/source/playbook/commands/loop.rst
@@ -41,30 +41,38 @@ The current item is accessible as the `$LOOP_ITEM` variable.
 **Loop with range**:
 This mode iterates over a range of integers. The current index is accessible as the `$LOOP_INDEX` variable.
 
+**Loop until condition is fulfilled**
+This mode iterates indefinitely until the condition is fulfilled. (Checked before every command within the loop)
+
 .. confval:: cmd
 
-   The loop condition. This defines how the loop should iterate, either over a list or a range of values.
+   The loop condition. This defines how the loop should iterate, either over a list or a range of values, or idefinitely until the
+   condition defined in until() is rached.
 
    :type: str
+   :required: ``True``
 
    Examples:
 
    - **items(LISTA)**: Iterate over the elements of a list named `LISTA`.
    - **range(0, 10)**: Iterate over a range from 0 to 9.
+   - **until(PORT == 7)
 
 .. confval:: break_condition
 
-   This condition is checked before every command in the loop.
+   If defined, this condition is checked before every command in the loop.
    If the condition evaluates to `True`, break out of the loop.
    Supports the same operators like :confval:`only_if`.
 
    :type: str
+   :required: ``False``
 
 .. confval:: commands
 
    The list of commands to execute during each iteration of the loop. These commands are executed once per iteration, with loop-specific variables (`$LOOP_ITEM` or `$LOOP_INDEX`) available for substitution.
 
    :type: list[Command]
+   :required: ``True``
 
    .. code-block:: yaml
 

--- a/docs/source/playbook/commands/loop.rst
+++ b/docs/source/playbook/commands/loop.rst
@@ -43,6 +43,7 @@ This mode iterates over a range of integers. The current index is accessible as 
 
 **Loop until condition is fulfilled**
 This mode iterates indefinitely until the condition is fulfilled. (Checked before every command within the loop)
+The current index/iteration of the loop is also accessible as the `$LOOP_INDEX` variable
 
 .. confval:: cmd
 
@@ -56,7 +57,7 @@ This mode iterates indefinitely until the condition is fulfilled. (Checked befor
 
    - **items(LISTA)**: Iterate over the elements of a list named `LISTA`.
    - **range(0, 10)**: Iterate over a range from 0 to 9.
-   - **until(PORT == 7)
+   - **until($PORT == 7)
 
 .. confval:: break_condition
 

--- a/docs/source/playbook/commands/loop.rst
+++ b/docs/source/playbook/commands/loop.rst
@@ -64,7 +64,7 @@ The current index/iteration of the loop is also accessible as the `$LOOP_INDEX` 
 
    If defined, this condition is checked before every command in the loop.
    If the condition evaluates to `True`, break out of the loop.
-   Supports the same operators like :confval:`only_if`.
+   Supports the same operators as :confval:`only_if`.
 
    :type: str
    :required: ``False``

--- a/docs/source/playbook/commands/loop.rst
+++ b/docs/source/playbook/commands/loop.rst
@@ -52,6 +52,14 @@ This mode iterates over a range of integers. The current index is accessible as 
    - **items(LISTA)**: Iterate over the elements of a list named `LISTA`.
    - **range(0, 10)**: Iterate over a range from 0 to 9.
 
+.. confval:: break_condition
+
+   This condition is checked before every command in the loop.
+   If the condition evaluates to `True`, break out of the loop.
+   Supports the same operators like :confval:`only_if`.
+
+   :type: str
+
 .. confval:: commands
 
    The list of commands to execute during each iteration of the loop. These commands are executed once per iteration, with loop-specific variables (`$LOOP_ITEM` or `$LOOP_INDEX`) available for substitution.

--- a/docs/source/playbook/vars.rst
+++ b/docs/source/playbook/vars.rst
@@ -31,6 +31,11 @@ $ATTACKMATE_FOO.
 
    For more information about using the variables see `string.Template <https://docs.python.org/3/library/string.html#string.Template>`_
 
+
+.. note::
+
+   variables in cmd settings of a loop command will be substituted on every iteration of the loop, see :ref:`loop`
+
 Builtin Variables
 =================
 

--- a/examples/includes/gather_commands.yml
+++ b/examples/includes/gather_commands.yml
@@ -23,4 +23,3 @@ commands:
     cmd: post/linux/gather/enum_protections
     options:
       SESSION: $GATHER_SESSION
-

--- a/src/attackmate/executors/baseexecutor.py
+++ b/src/attackmate/executors/baseexecutor.py
@@ -29,15 +29,22 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
 
     """
 
-    def __init__(self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig()):
+    def __init__(
+        self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig(), substitute_cmd_vars=True
+    ):
         """Constructor for BaseExecutor
-
         Parameters
         ----------
-        cmdconfig : str, default `None`
-            cmd_config settings.
-
+        pm : ProcessManager
+            Process manager instance.
+        varstore : VariableStore
+            Variable store instance.
+        cmdconfig : CommandConfig, default `None`
+            Command configuration settings.
+        substitute_cmd_vars : bool, default `True`
+            Flag to enable or disable variable substitution in command.cmd
         """
+
         Background.__init__(self, pm)
         CmdVars.__init__(self, varstore)
         ExitOnError.__init__(self)
@@ -46,6 +53,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
         self.json_logger = logging.getLogger('json')
         self.cmdconfig = cmdconfig
         self.output = logging.getLogger('output')
+        self.substitute_cmd_vars = substitute_cmd_vars
 
     def run(self, command: BaseCommand):
         """Execute the command
@@ -54,7 +62,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
         executes the given command. This method sets the
         run_count to 1 and runs the method exec(). Please note
         that this function will exchange all variables of the BaseCommand
-        with the values of the VariableStore!
+        with the values of the VariableStore if substitute_cmd_vars is True!
 
         Parameters
         ----------
@@ -62,6 +70,7 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
             The settings for the command to execute
 
         """
+
         if command.only_if:
             if not Conditional.test(self.varstore.substitute(command.only_if, True)):
                 if hasattr(command, 'type'):
@@ -72,9 +81,9 @@ class BaseExecutor(ExitOnError, CmdVars, Looper, Background):
         self.reset_run_count()
         self.logger.debug(f"Template-Command: '{command.cmd}'")
         if command.background:
-            self.exec_background(self.replace_variables(command))
+            self.exec_background(self.substitute_template_vars(command, self.substitute_cmd_vars))
         else:
-            self.exec(self.replace_variables(command))
+            self.exec(self.substitute_template_vars(command, self.substitute_cmd_vars))
 
     def log_command(self, command):
         """Log starting-status of the command"""

--- a/src/attackmate/executors/common/loopexecutor.py
+++ b/src/attackmate/executors/common/loopexecutor.py
@@ -37,11 +37,11 @@ class LoopExecutor(BaseExecutor):
         self.logger.info('Looping commands')
 
     def break_condition_met(self, command: LoopCommand) -> bool:
-        if not command.break_condition:
+        if not command.break_if:
             return False
-        condition = Template(command.break_condition).safe_substitute(**self.varstore.variables)
+        condition = Template(command.break_if).safe_substitute(**self.varstore.variables)
         if Conditional.test(condition):
-            self.logger.warning('Breaking out of loop due to condition: %s', command.break_condition)
+            self.logger.warning('Breaking out of loop due to condition: %s', command.break_if)
             return True
         return False
 

--- a/src/attackmate/executors/common/loopexecutor.py
+++ b/src/attackmate/executors/common/loopexecutor.py
@@ -35,7 +35,7 @@ class LoopExecutor(BaseExecutor):
 
     def break_condition_met(self, command: LoopCommand):
         if command.break_condition:
-            if Conditional.test(self.varstore.substitute(command.break_condition)):
+            if Conditional.test(Template(command.break_condition).safe_substitute(**self.varstore.variables)):
                 self.logger.warning('Breaking out of loop')
                 return True
             else:

--- a/src/attackmate/schemas/loop.py
+++ b/src/attackmate/schemas/loop.py
@@ -1,28 +1,27 @@
 from attackmate.schemas.base import BaseCommand
 from pydantic import field_validator
-from typing import Literal
-from typing import List, Union
+from typing import Literal, Union, Optional, List
 from .sleep import SleepCommand
 from .shell import ShellCommand
 from .setvar import SetVarCommand
 from .include import IncludeCommand
-from .metasploit import (MsfModuleCommand,
-                         MsfSessionCommand,
-                         MsfPayloadCommand)
+from .metasploit import MsfModuleCommand, MsfSessionCommand, MsfPayloadCommand
 
-from .sliver import (SliverSessionCDCommand,
-                     SliverSessionLSCommand,
-                     SliverSessionNETSTATCommand,
-                     SliverSessionEXECCommand,
-                     SliverSessionMKDIRCommand,
-                     SliverSessionSimpleCommand,
-                     SliverSessionDOWNLOADCommand,
-                     SliverSessionUPLOADCommand,
-                     SliverSessionPROCDUMPCommand,
-                     SliverSessionRMCommand,
-                     SliverSessionTERMINATECommand,
-                     SliverHttpsListenerCommand,
-                     SliverGenerateCommand)
+from .sliver import (
+    SliverSessionCDCommand,
+    SliverSessionLSCommand,
+    SliverSessionNETSTATCommand,
+    SliverSessionEXECCommand,
+    SliverSessionMKDIRCommand,
+    SliverSessionSimpleCommand,
+    SliverSessionDOWNLOADCommand,
+    SliverSessionUPLOADCommand,
+    SliverSessionPROCDUMPCommand,
+    SliverSessionRMCommand,
+    SliverSessionTERMINATECommand,
+    SliverHttpsListenerCommand,
+    SliverGenerateCommand,
+)
 from .ssh import SSHCommand, SFTPCommand
 from .http import WebServCommand, HttpClientCommand
 from .father import FatherCommand
@@ -31,36 +30,38 @@ from .debug import DebugCommand
 from .regex import RegExCommand
 
 
-Commands = List[Union[
-                         ShellCommand,
-                         MsfModuleCommand,
-                         MsfSessionCommand,
-                         MsfPayloadCommand,
-                         SleepCommand,
-                         SSHCommand,
-                         FatherCommand,
-                         SFTPCommand,
-                         DebugCommand,
-                         SetVarCommand,
-                         RegExCommand,
-                         TempfileCommand,
-                         IncludeCommand,
-                         WebServCommand,
-                         HttpClientCommand,
-                         SliverSessionCDCommand,
-                         SliverSessionLSCommand,
-                         SliverSessionNETSTATCommand,
-                         SliverSessionEXECCommand,
-                         SliverSessionMKDIRCommand,
-                         SliverSessionSimpleCommand,
-                         SliverSessionDOWNLOADCommand,
-                         SliverSessionUPLOADCommand,
-                         SliverSessionPROCDUMPCommand,
-                         SliverSessionRMCommand,
-                         SliverSessionTERMINATECommand,
-                         SliverHttpsListenerCommand,
-                         SliverGenerateCommand
-                         ]]
+Commands = List[
+    Union[
+        ShellCommand,
+        MsfModuleCommand,
+        MsfSessionCommand,
+        MsfPayloadCommand,
+        SleepCommand,
+        SSHCommand,
+        FatherCommand,
+        SFTPCommand,
+        DebugCommand,
+        SetVarCommand,
+        RegExCommand,
+        TempfileCommand,
+        IncludeCommand,
+        WebServCommand,
+        HttpClientCommand,
+        SliverSessionCDCommand,
+        SliverSessionLSCommand,
+        SliverSessionNETSTATCommand,
+        SliverSessionEXECCommand,
+        SliverSessionMKDIRCommand,
+        SliverSessionSimpleCommand,
+        SliverSessionDOWNLOADCommand,
+        SliverSessionUPLOADCommand,
+        SliverSessionPROCDUMPCommand,
+        SliverSessionRMCommand,
+        SliverSessionTERMINATECommand,
+        SliverHttpsListenerCommand,
+        SliverGenerateCommand,
+    ]
+]
 
 
 class LoopCommand(BaseCommand):
@@ -72,3 +73,4 @@ class LoopCommand(BaseCommand):
     type: Literal['loop']
     cmd: str = 'loop condition'
     commands: Commands
+    break_condition: Optional[str] = None

--- a/src/attackmate/schemas/loop.py
+++ b/src/attackmate/schemas/loop.py
@@ -73,4 +73,4 @@ class LoopCommand(BaseCommand):
     type: Literal['loop']
     cmd: str = 'loop condition'
     commands: Commands
-    break_condition: Optional[str] = None
+    break_if: Optional[str] = None

--- a/test/units/test_baseexecutor.py
+++ b/test/units/test_baseexecutor.py
@@ -29,7 +29,7 @@ class TestBaseExecutor:
         varstore.set_variable('wonder', 'woman')
         be = BaseExecutor(ProcessManager(), varstore)
         bc = BaseCommand(cmd='$foo hello', exit_on_error=False, loop_if_not='world $wonder')
-        replaced = be.replace_variables(bc)
+        replaced = be.substitute_template_vars(bc)
         assert replaced.cmd == 'bar hello'
         # exit_on_error must not have changed!
         assert replaced.exit_on_error is False
@@ -45,7 +45,7 @@ class TestBaseExecutor:
         varstore.set_variable('wonder', 'woman')
         be = BaseExecutor(ProcessManager(), varstore)
         rex = RegExCommand(type='regex', cmd='$foo.*', output={'foo$foo': '$foo'}, input='hello world')
-        replaced = be.replace_variables(rex)
+        replaced = be.substitute_template_vars(rex)
         assert replaced.cmd == 'bar.*'
         assert replaced.output['foo$foo'] == 'bar'
         # input must not have changed!
@@ -61,10 +61,15 @@ class TestBaseExecutor:
         varstore.set_variable('foo', 'bar')
         varstore.set_variable('wonder', 'woman')
         be = BaseExecutor(ProcessManager(), varstore)
-        sl = SliverSessionEXECCommand(type='sliver-session', cmd='execute',
-                                      exe='hello $foo', output=False, session='$foo $woman',
-                                      args=['woo $wonder', 'hoo $foo'])
-        replaced = be.replace_variables(sl)
+        sl = SliverSessionEXECCommand(
+            type='sliver-session',
+            cmd='execute',
+            exe='hello $foo',
+            output=False,
+            session='$foo $woman',
+            args=['woo $wonder', 'hoo $foo'],
+        )
+        replaced = be.substitute_template_vars(sl)
         assert replaced.cmd == 'execute'
         assert replaced.session == 'bar $woman'
         assert replaced.exe == 'hello bar'

--- a/test/units/test_loopexecutor.py
+++ b/test/units/test_loopexecutor.py
@@ -24,9 +24,9 @@ class TestLoopExecutor:
         caplog.set_level(logging.INFO)
         self.varstore.clear()
         self.varstore.set_variable('one', ['first', 'second'])
-        lc = LoopCommand(type='loop',
-                         cmd='items($one)',
-                         commands=[DebugCommand(cmd='$LOOP_ITEM', type='debug')])
+        lc = LoopCommand(
+            type='loop', cmd='items($one)', commands=[DebugCommand(cmd='$LOOP_ITEM', type='debug')]
+        )
         self.loop_executor.run(lc)
         assert 'Debug: \'first\'' in [rec.message for rec in caplog.records]
         assert 'Debug: \'second\'' in [rec.message for rec in caplog.records]
@@ -35,9 +35,23 @@ class TestLoopExecutor:
         caplog.set_level(logging.INFO)
         self.varstore.clear()
         self.varstore.set_variable('one', ['first', 'second'])
-        lc = LoopCommand(type='loop',
-                         cmd='range(1,3)',
-                         commands=[DebugCommand(cmd='$LOOP_INDEX', type='debug')])
+        lc = LoopCommand(
+            type='loop', cmd='range(1,3)', commands=[DebugCommand(cmd='$LOOP_INDEX', type='debug')]
+        )
         self.loop_executor.run(lc)
         assert 'Debug: \'1\'' in [rec.message for rec in caplog.records]
         assert 'Debug: \'2\'' in [rec.message for rec in caplog.records]
+
+    def test_until(self, caplog):
+        caplog.set_level(logging.INFO)
+        self.varstore.clear()
+        lc = LoopCommand(
+            type='loop',
+            cmd='until($LOOP_INDEX == 2)',
+            commands=[DebugCommand(cmd='$LOOP_INDEX', type='debug')],
+        )
+        self.loop_executor.run(lc)
+        # Verify that the loop ran exactly 2 times
+        assert 'Debug: \'0\'' in [rec.message for rec in caplog.records]
+        assert 'Debug: \'1\'' in [rec.message for rec in caplog.records]
+        assert 'Debug: \'2\'' not in [rec.message for rec in caplog.records]


### PR DESCRIPTION
relates to issue #134 and issue #123
- adds a `break_condition `to the loop command
- adds a `until() `option to the loop cmd options (additionally to` range()` and `items()` )
- docs
- unit tests