### PR TITLE
132 append to log files

### DIFF
--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -7,7 +7,7 @@ AttackMate ships with a executable stub called "attackmate" that can be called l
 ::
 
    attackmate -h
-   usage: attackmate [-h] --config CONFIG [--debug] [--version]
+   usage: attackmate [-h] --config CONFIG [--debug] [--version] [--json] [--append_logs]
 
    AttackMate is an attack orchestration tool that executes full attack-chains based on playbooks.
 
@@ -17,6 +17,7 @@ AttackMate ships with a executable stub called "attackmate" that can be called l
      --debug          Enable verbose output
      --version        show program's version number and exit
      --json           log commands to attackmate.json
+     --append_logs    append logs to attackmate.log, output.log and attackmate.json instead of overwriting
 
    (Austrian Institute of Technology) https://aecid.ait.ac.at Version: 0.2.0
 

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -24,7 +24,7 @@ def parse_args():
         '--append_logs',
         action='store_true',
         default=False,
-        help='append logs to attackmatelog, output.log and attackmate.json instead of overwriting',
+        help='append logs to attackmate.log, output.log and attackmate.json instead of overwriting',
     )
     parser.add_argument('--version', action='version', version=__version_string__)
     parser.add_argument('playbook', help='Playbook in yaml-format')

--- a/src/attackmate/__main__.py
+++ b/src/attackmate/__main__.py
@@ -20,6 +20,12 @@ def parse_args():
     parser.add_argument('--config', help='Configfile in yaml-format')
     parser.add_argument('--debug', action='store_true', default=False, help='Enable verbose output')
     parser.add_argument('--json', action='store_true', default=False, help='log commands to attackmate.json')
+    parser.add_argument(
+        '--append_logs',
+        action='store_true',
+        default=False,
+        help='append logs to attackmatelog, output.log and attackmate.json instead of overwriting',
+    )
     parser.add_argument('--version', action='version', version=__version_string__)
     parser.add_argument('playbook', help='Playbook in yaml-format')
     return parser.parse_args()
@@ -27,9 +33,9 @@ def parse_args():
 
 def main():
     args = parse_args()
-    logger = initialize_logger(args.debug)
-    initialize_output_logger(args.debug)
-    initialize_json_logger(args.json)
+    logger = initialize_logger(args.debug, args.append_logs)
+    initialize_output_logger(args.debug, args.append_logs)
+    initialize_json_logger(args.json, args.append_logs)
     hacky = AttackMate(parse_playbook(args.playbook, logger), parse_config(args.config, logger))
     sys.exit(hacky.main())
 

--- a/src/attackmate/logging_setup.py
+++ b/src/attackmate/logging_setup.py
@@ -4,7 +4,7 @@ import logging
 from colorlog import ColoredFormatter
 
 
-def _create_file_handler(
+def create_file_handler(
     file_name: str, append_logs: bool, formatter: logging.Formatter
 ) -> logging.FileHandler:
     mode = 'a' if append_logs else 'w'
@@ -23,7 +23,7 @@ def initialize_output_logger(debug: bool, append_logs: bool):
     formatter = logging.Formatter(
         '--- %(asctime)s %(levelname)s: ---\n\n%(message)s', datefmt='%Y-%m-%d %H:%M:%S'
     )
-    file_handler = _create_file_handler('output.log', append_logs, formatter)
+    file_handler = create_file_handler('output.log', append_logs, formatter)
     output_logger.addHandler(file_handler)
 
 
@@ -43,7 +43,7 @@ def initialize_logger(debug: bool, append_logs: bool):
     # plain text output
     playbook_logger.addHandler(console_handler)
     formatter = logging.Formatter('%(asctime)s %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-    file_handler = _create_file_handler('attackmate.log', append_logs, formatter)
+    file_handler = create_file_handler('attackmate.log', append_logs, formatter)
     playbook_logger.addHandler(file_handler)
 
     return playbook_logger

--- a/src/attackmate/logging_setup.py
+++ b/src/attackmate/logging_setup.py
@@ -4,21 +4,30 @@ import logging
 from colorlog import ColoredFormatter
 
 
-def initialize_output_logger(debug: bool):
+def _create_file_handler(
+    file_name: str, append_logs: bool, formatter: logging.Formatter
+) -> logging.FileHandler:
+    mode = 'a' if append_logs else 'w'
+    file_handler = logging.FileHandler(file_name, mode=mode)
+    file_handler.setFormatter(formatter)
+
+    return file_handler
+
+
+def initialize_output_logger(debug: bool, append_logs: bool):
     output_logger = logging.getLogger('output')
     if debug:
         output_logger.setLevel(logging.DEBUG)
     else:
         output_logger.setLevel(logging.INFO)
-    file_handler = logging.FileHandler('output.log', mode='w')
     formatter = logging.Formatter(
         '--- %(asctime)s %(levelname)s: ---\n\n%(message)s', datefmt='%Y-%m-%d %H:%M:%S'
     )
-    file_handler.setFormatter(formatter)
+    file_handler = _create_file_handler('output.log', append_logs, formatter)
     output_logger.addHandler(file_handler)
 
 
-def initialize_logger(debug: bool):
+def initialize_logger(debug: bool, append_logs: bool):
     playbook_logger = logging.getLogger('playbook')
     if debug:
         playbook_logger.setLevel(logging.DEBUG)
@@ -33,22 +42,20 @@ def initialize_logger(debug: bool):
 
     # plain text output
     playbook_logger.addHandler(console_handler)
-    file_handler = logging.FileHandler('attackmate.log', mode='w')
     formatter = logging.Formatter('%(asctime)s %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-    file_handler.setFormatter(formatter)
+    file_handler = _create_file_handler('attackmate.log', append_logs, formatter)
     playbook_logger.addHandler(file_handler)
 
     return playbook_logger
 
 
-def initialize_json_logger(json: bool):
+def initialize_json_logger(json: bool, append_logs: bool):
     if not json:
         return None
     json_logger = logging.getLogger('json')
     json_logger.setLevel(logging.DEBUG)
-    file_handler = logging.FileHandler('attackmate.json', mode='w')
     formatter = logging.Formatter('%(message)s')
-    file_handler.setFormatter(formatter)
+    file_handler = _create_file_handler('attackmate.json', append_logs, formatter)
     json_logger.addHandler(file_handler)
 
     return json_logger

--- a/src/attackmate/logging_setup.py
+++ b/src/attackmate/logging_setup.py
@@ -55,7 +55,7 @@ def initialize_json_logger(json: bool, append_logs: bool):
     json_logger = logging.getLogger('json')
     json_logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(message)s')
-    file_handler = _create_file_handler('attackmate.json', append_logs, formatter)
+    file_handler = create_file_handler('attackmate.json', append_logs, formatter)
     json_logger.addHandler(file_handler)
 
     return json_logger

--- a/test/units/test_logging.py
+++ b/test/units/test_logging.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch, MagicMock
+from logging import FileHandler
+import pytest
+from attackmate.logging_setup import initialize_output_logger, initialize_logger, initialize_json_logger
+
+
+@pytest.fixture
+def mock_file_handler():
+    with patch('logging.FileHandler', spec=FileHandler) as mock_file_handler:
+        yield mock_file_handler
+
+
+def test_initialize_output_logger_append_mode(mock_file_handler):
+    mock_handler_instance = MagicMock()
+    mock_file_handler.return_value = mock_handler_instance
+
+    initialize_output_logger(debug=True, append_logs=True)
+
+    mock_file_handler.assert_called_once_with('output.log', mode='a')
+    mock_handler_instance.setFormatter.assert_called_once()
+
+
+def test_initialize_logger_append_mode(mock_file_handler):
+    mock_handler_instance = MagicMock()
+    mock_file_handler.return_value = mock_handler_instance
+
+    initialize_logger(debug=False, append_logs=True)
+
+    mock_file_handler.assert_any_call('attackmate.log', mode='a')
+    mock_handler_instance.setFormatter.assert_called()
+
+
+def test_initialize_json_logger_append_mode(mock_file_handler):
+    mock_handler_instance = MagicMock()
+    mock_file_handler.return_value = mock_handler_instance
+
+    initialize_json_logger(json=True, append_logs=True)
+
+    mock_file_handler.assert_called_once_with('attackmate.json', mode='a')
+    mock_handler_instance.setFormatter.assert_called_once()

--- a/test/units/test_logging.py
+++ b/test/units/test_logging.py
@@ -1,40 +1,33 @@
-from unittest.mock import patch, MagicMock
-from logging import FileHandler
 import pytest
-from attackmate.logging_setup import initialize_output_logger, initialize_logger, initialize_json_logger
+from unittest.mock import patch, MagicMock
+from attackmate.logging_setup import create_file_handler
 
 
-@pytest.fixture
-def mock_file_handler():
-    with patch('logging.FileHandler', spec=FileHandler) as mock_file_handler:
-        yield mock_file_handler
+@patch('attackmate.logging_setup.logging.FileHandler')
+def test_create_file_handler_append_mode(MockFileHandler):
+    mock_handler = MagicMock()
+    MockFileHandler.return_value = mock_handler
+
+    file_name = 'test.log'
+    append_logs = True
+    formatter = MagicMock()
+
+    create_file_handler(file_name, append_logs, formatter)
+
+    MockFileHandler.assert_called_with(file_name, mode='a')
+    mock_handler.setFormatter.assert_called_with(formatter)
 
 
-def test_initialize_output_logger_append_mode(mock_file_handler):
-    mock_handler_instance = MagicMock()
-    mock_file_handler.return_value = mock_handler_instance
+@patch('attackmate.logging_setup.logging.FileHandler')
+def test_create_file_handler_write_mode(MockFileHandler):
+    mock_handler = MagicMock()
+    MockFileHandler.return_value = mock_handler
 
-    initialize_output_logger(debug=True, append_logs=True)
+    file_name = 'test.log'
+    append_logs = False
+    formatter = MagicMock()
 
-    mock_file_handler.assert_called_once_with('output.log', mode='a')
-    mock_handler_instance.setFormatter.assert_called_once()
+    create_file_handler(file_name, append_logs, formatter)
 
-
-def test_initialize_logger_append_mode(mock_file_handler):
-    mock_handler_instance = MagicMock()
-    mock_file_handler.return_value = mock_handler_instance
-
-    initialize_logger(debug=False, append_logs=True)
-
-    mock_file_handler.assert_any_call('attackmate.log', mode='a')
-    mock_handler_instance.setFormatter.assert_called()
-
-
-def test_initialize_json_logger_append_mode(mock_file_handler):
-    mock_handler_instance = MagicMock()
-    mock_file_handler.return_value = mock_handler_instance
-
-    initialize_json_logger(json=True, append_logs=True)
-
-    mock_file_handler.assert_called_once_with('attackmate.json', mode='a')
-    mock_handler_instance.setFormatter.assert_called_once()
+    MockFileHandler.assert_called_with(file_name, mode='w')
+    mock_handler.setFormatter.assert_called_with(formatter)


### PR DESCRIPTION
relates to issue #132 
- adds a command line argument` --append_logs` to append to logfiles instead of overwriting
- adds documentation
- unit tests