### PR TITLE
Generalized variable substitution for LoopExecutor

### DIFF
--- a/src/attackmate/executors/common/loopexecutor.py
+++ b/src/attackmate/executors/common/loopexecutor.py
@@ -45,12 +45,28 @@ class LoopExecutor(BaseExecutor):
             return True
         return False
 
+    def substitute_variables_in_command(self, command_obj, placeholders: dict):
+        """
+        Replaces all occurrences of placeholders in *any* string attribute
+        of the command_obj with the values from placeholders.
+        E.g. if placeholders = {'LOOP_ITEM': 'https://example.com'},
+             and command_obj.url = '$LOOP_ITEM', then it becomes 'https://example.com'.
+        """
+        for attr_name, attr_val in vars(command_obj).items():
+            if isinstance(attr_val, str):
+                new_val = Template(attr_val).safe_substitute(placeholders)
+                setattr(command_obj, attr_name, new_val)
+
     def loop_range(self, command: LoopCommand, start: int, end: int) -> None:
         for x in range(start, end):
             for cmd in command.commands:
                 template_cmd: Command = copy.deepcopy(cmd)
-                tpl = Template(template_cmd.cmd)
-                template_cmd.cmd = tpl.substitute(LOOP_INDEX=x, **self.varstore.variables)
+                placeholders = {
+                    'LOOP_INDEX': x,
+                    **self.varstore.variables,
+                }
+                print(placeholders)
+                self.substitute_variables_in_command(template_cmd, placeholders)
                 if self.break_condition_met(command):
                     return
                 self.runfunc([template_cmd])
@@ -59,8 +75,11 @@ class LoopExecutor(BaseExecutor):
         for x in iterable:
             for cmd in command.commands:
                 template_cmd: Command = copy.deepcopy(cmd)
-                tpl = Template(template_cmd.cmd)
-                template_cmd.cmd = tpl.substitute(LOOP_ITEM=x, **self.varstore.variables)
+                placeholders = {
+                    'LOOP_ITEM': x,
+                    **self.varstore.variables,
+                }
+                self.substitute_variables_in_command(template_cmd, placeholders)
                 if self.break_condition_met(command):
                     return
                 self.runfunc([template_cmd])

--- a/src/attackmate/executors/common/loopexecutor.py
+++ b/src/attackmate/executors/common/loopexecutor.py
@@ -65,7 +65,6 @@ class LoopExecutor(BaseExecutor):
                     'LOOP_INDEX': x,
                     **self.varstore.variables,
                 }
-                print(placeholders)
                 self.substitute_variables_in_command(template_cmd, placeholders)
                 if self.break_condition_met(command):
                     return

--- a/src/attackmate/executors/common/loopexecutor.py
+++ b/src/attackmate/executors/common/loopexecutor.py
@@ -53,7 +53,7 @@ class LoopExecutor(BaseExecutor):
              and command_obj.url = '$LOOP_ITEM', then it becomes 'https://example.com'.
         """
         for attr_name, attr_val in vars(command_obj).items():
-            if isinstance(attr_val, str):
+            if isinstance(attr_val, str) and "$" in attr_val:
                 new_val = Template(attr_val).safe_substitute(placeholders)
                 setattr(command_obj, attr_name, new_val)
 


### PR DESCRIPTION
Previously, the LoopExecutor only substituted variables in the `cmd` field. This was insufficient for commands with additional attributes, which may also contain placeholders.

This PR enhances the LoopExecutor to support generalized variable substitution for all string attributes in commands.

Units tests were written with the help of the sleep command to make sure it works with its `seconds` field. It was also successfully tested with the incoming browser executor. To manually test it with the sleep command, here is an example playbook:
```yml
vars:
  LISTA:
    - 1
    - 2
    - 3
    - 4
    - 5

commands:
  - type: loop
    cmd: "range(0,5)"
    commands:
      - type: sleep
        seconds: $LOOP_INDEX
  - type: loop
    cmd: "items(LISTA)"
    commands:
      - type: sleep
        seconds: $LOOP_ITEM
```
