### PR TITLE
Implemented pause-key for debug command

### DIFF
--- a/docs/source/playbook/commands/debug.rst
+++ b/docs/source/playbook/commands/debug.rst
@@ -39,4 +39,12 @@ purposes only.
    that this is an exceptional break.
 
    :type: bool
-   :default: ``True``
+   :default: ``False``
+
+.. confval:: wait_for_key
+
+   This setting causes the programm to pause until the user
+   hits the enter key.
+
+   :type: bool
+   :default: ``False``

--- a/src/attackmate/executors/common/debugexecutor.py
+++ b/src/attackmate/executors/common/debugexecutor.py
@@ -21,6 +21,9 @@ class DebugExecutor(BaseExecutor):
     def _exec_cmd(self, command: DebugCommand) -> Result:
         self.setoutuptvars = False
         ret = 0
+        if command.wait_for_key:
+            self.logger.warning("Type enter to continue")
+            input()
         if command.exit:
             ret = 1
 

--- a/src/attackmate/schemas/debug.py
+++ b/src/attackmate/schemas/debug.py
@@ -6,4 +6,5 @@ class DebugCommand(BaseCommand):
     type: Literal['debug']
     varstore: bool = False
     exit: bool = False
+    wait_for_key: bool = False
     cmd: str = ''


### PR DESCRIPTION
This PR implements a pause-setting for the debug command. If wait_for_key is set to "True", the debug-command will wait until the user hits the enter button.

This PR fixes #147 