### PR TITLE
POC attackmate API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ dependencies = [
     "httpx",
     "httpx[http2]",
     "vncdotool",
-    "pytest-mock"
+    "pytest-mock",
+    "fastapi",
+    "json-rpc",
+    "uvicorn",
 ]
 dynamic = ["version"]
 

--- a/src/attackmate/client.py
+++ b/src/attackmate/client.py
@@ -1,0 +1,19 @@
+import requests
+
+json_rpc_url = "http://192.168.10.65:8000/attackmate"
+
+
+command_request = {
+    "jsonrpc": "2.0",
+    "method": "do_command",
+    "params": {
+        "type": "debug",
+        "cmd": "hello world",
+        "args": [],
+        "timeout": 10
+    },
+    "id": 1
+}
+
+response = requests.post(json_rpc_url, json=command_request)
+print(response.json())

--- a/src/attackmate/server.py
+++ b/src/attackmate/server.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI
+from jsonrpc import JSONRPCResponseManager, dispatcher
+from attackmate.attackmate import AttackMate
+from attackmate.command import Command
+import logging
+import json
+
+# Initialize FastAPI app
+app = FastAPI()
+
+# Initialize logger
+logger = logging.getLogger("attackmate-server")
+logging.basicConfig(level=logging.INFO)
+
+attackmate_instance = AttackMate()
+
+@dispatcher.add_method
+def do_command(type, cmd, **kwargs):
+    """
+    Execute a command using AttackMate.
+    Expects JSON-RPC input with a command dictionary.
+    """
+    try:
+        # Create the command instance
+        command = Command.create(type=type, cmd=cmd, **kwargs)
+        result = attackmate_instance.run_command(command)
+        return {"output": result.stdout, "status": result.returncode}
+    except Exception as e:
+        return {"error": str(e)}
+
+@app.post("/attackmate")
+async def json_rpc_handler(request: dict):
+    response = JSONRPCResponseManager.handle(json.dumps(request), dispatcher)
+    return response.json


### PR DESCRIPTION
- lets AttackMate run as a FastAPI server
- requests to execute commands via json-rpc


**How to test:**
install dependencies per pyproject.toml (fastapi, json-rpc, uvicorn)

**SUBSTITUTE THE IP in client.py for your attackers ip**

start server:
`uvicorn src.attackmate.server:app --host 0.0.0.0 --port 8000 `
![image](https://github.com/user-attachments/assets/ffad0b57-4d86-44d3-bb85-696de49f3d12)

execute client script:
`python3 src/attackmate/client.py`
![image](https://github.com/user-attachments/assets/e0c0c982-12eb-4c5e-aae4-dd9f53b6edda)



