### PR TITLE
Browser executor

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,6 +29,9 @@ jobs:
         pip install flake8 pytest
         pip install -e .
         if [ -f test/requirements.txt ]; then pip install -r test/requirements.txt; fi
+    - name: Install Playwright browser
+      run: |
+        python -m playwright install chromium --with-deps --only-shell
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
 # build: docker build -t attackmate .
 
-From kalilinux/kali-rolling
+FROM kalilinux/kali-rolling
 
 LABEL maintainer="wolfgang.hotwagner@ait.ac.at"
 
 ENV VIRTUAL_ENV=/opt/venv
 ARG DEBIAN_FRONTEND=noninteractive
 # Essentials
-RUN apt-get update && apt-get install -y python3 python3-pip python3-venv nmap nikto ffuf
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv libmagic1 nmap nikto ffuf
 # For Father rootkit
 RUN apt-get update && apt-get install -y gcc libpam0g-dev libgcrypt20-dev nasm build-essential
 # For Sliver-Workaround https://github.com/moloch--/sliver-py/issues/28
 RUN apt-get update && apt install -y python3-dev libssl-dev git
+# For Playwright (Kali packages that satisfy Ubuntu's deps)
+RUN apt-get update && apt-get install -y libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxcomposite1 \
+    libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libatspi2.0-0 libgtk-3-0 \
+    libgtk-3-0 libxcursor1 libcairo2 libasound2 libasound2t64 fonts-unifont libjpeg62-turbo libpng16-16 \
+    libwebp-dev libvpx-dev libicu72 libx264-164 libenchant-2-2
 
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -19,6 +24,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ADD . /attackmate
 RUN pip install /attackmate
 WORKDIR /attackmate
+# Playwright
+RUN playwright install
 # Sliver-Workaround
 RUN git clone https://github.com/grpc/grpc \
     && cd grpc \

--- a/docs/source/playbook/commands/browser.rst
+++ b/docs/source/playbook/commands/browser.rst
@@ -1,0 +1,95 @@
+=======
+browser
+=======
+
+Execute commands using a Playwright-managed browser (Chromium). This executor can launch a browser, navigate to pages, click elements, type into fields, and take screenshots.
+
+.. note::
+
+   By default, if no session is provided or created, the command will run in an ephemeral browser session
+   (launched and destroyed for each command). If you want to persist browser state (cookies, localStorage,
+   etc.) across multiple commands, use the :confval:`creates_session` or :confval:`session` options.
+
+.. code-block:: yaml
+
+   vars:
+     $URL: "https://www.wikipedia.org/"
+
+   commands:
+     # Create a new named browser session called "my_session"
+     - type: browser
+       cmd: visit
+       url: $URL
+       creates_session: my_session
+
+     # Reuse the existing "my_session" to type text into an input field
+     - type: browser
+       cmd: type
+       selector: "input[id='searchInput']"
+       text: "Test"
+       session: "my_session"
+
+     # Click on the "submit" button, still reusing "my_session"
+     - type: browser
+       cmd: click
+       selector: "button[type='submit']"
+       session: "my_session"
+
+    # Take a screenshot of the current page in the "my_session"
+     - type: browser
+       cmd: screenshot
+       screenshot_path: "example.png"
+       session: "my_session"
+
+     # Open a page in an ephemeral session (automatically closed)
+     - type: browser
+       cmd: visit
+       url: "https://www.google.com"
+
+.. confval:: cmd
+
+   Specifies the browser action to execute. One of ``visit``, ``click``, ``type``, ``screenshot``.
+
+   :type: str
+
+.. confval:: url
+
+   URL to visit for the ``visit`` command.
+
+   :type: str
+
+.. confval:: selector
+
+   CSS selector identifying the element to interact with for the ``click`` or ``type`` commands.
+
+   :type: str
+
+.. confval:: text
+
+   Text to type into the specified element for the ``type`` command.
+
+   :type: str
+
+.. confval:: screenshot_path
+
+   Specifies the file path where a screenshot should be saved for the ``screenshot`` command.
+
+   :type: str
+
+.. confval:: creates_session
+
+   A session name to create when running this command. Once created, the session is retained in the
+   session store for reuse by subsequent ``browser`` commands that specify ``session``.
+
+   If a session of the same name already exists, it is automatically closed before creating the new one.
+
+   :type: str
+
+.. confval:: session
+
+   Name of an existing session to reuse. This session must have been created previously with
+   ``creates_session``. If omitted, the command will either create a new ephemeral session
+   (destroyed after the command finishes) or reuse the default ephemeral session if the code
+   supports that usage pattern.
+
+   :type: str

--- a/docs/source/playbook/commands/browser.rst
+++ b/docs/source/playbook/commands/browser.rst
@@ -93,3 +93,21 @@ Execute commands using a Playwright-managed browser (Chromium). This executor ca
    supports that usage pattern.
 
    :type: str
+
+.. confval:: headless
+
+   Run the browser in headless mode.
+   Useful for CI/CD pipelines or servers without a GUI.
+
+   :type: bool
+   :default: false
+
+    Example:
+
+    .. code-block:: yaml
+
+       - type: browser
+         cmd: visit
+         url: "https://example.com"
+         creates_session: ci_session
+         headless: true

--- a/docs/source/playbook/commands/index.rst
+++ b/docs/source/playbook/commands/index.rst
@@ -211,6 +211,7 @@ The next pages will describe all possible commands in detail.
    :maxdepth: 4
    :hidden:
 
+   browser
    debug
    father
    httpclient

--- a/docs/source/preparation/index.rst
+++ b/docs/source/preparation/index.rst
@@ -5,7 +5,7 @@ Preparation
 Even though AttackMate can be used out of the box, for some commands
 it is necessary to install and set up the corresponding tools. The following
 pages are going to explain how to setup and install :ref:`Sliver <prep_sliver>`
-and :ref:`Metasploit <prep_msf>`
+and :ref:`Metasploit <prep_msf>`, as well as :ref:`Playwright <playwright>` for browser-based commands.
 
 .. toctree::
    :maxdepth: 1
@@ -13,3 +13,4 @@ and :ref:`Metasploit <prep_msf>`
 
    metasploit
    sliver
+   playwright

--- a/docs/source/preparation/playwright.rst
+++ b/docs/source/preparation/playwright.rst
@@ -1,0 +1,19 @@
+.. _playwright:
+
+==================
+Prepare Playwright
+==================
+
+To run browser-based commands with the ``browser`` executor, you need to install the Playwright browser binaries
+(as of now, it only supports Chromium, so it's sufficient to install that):
+
+::
+
+  # Install Chromium
+  playwright install chromium
+
+  # Update package lists to ensure latest versions are available
+  sudo apt-get update
+
+  # Install required system dependencies
+  sudo apt-get install -y libnss3 libnspr4 libasound2t64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "tabulate",
     "python-magic",
     "httpx",
-    "httpx[http2]"
+    "httpx[http2]",
+    "playwright"
 ]
 dynamic = ["version"]
 

--- a/src/attackmate/executors/__init__.py
+++ b/src/attackmate/executors/__init__.py
@@ -1,3 +1,4 @@
+from .browser.browserexecutor import BrowserExecutor
 from .shell.shellexecutor import ShellExecutor
 from .ssh.sshexecutor import SSHExecutor
 from .metasploit.msfsessionexecutor import MsfSessionExecutor
@@ -20,6 +21,7 @@ from .common.jsonexecutor import JsonExecutor
 
 
 __all__ = [
+    'BrowserExecutor',
     'ShellExecutor',
     'SSHExecutor',
     'MsfSessionExecutor',

--- a/src/attackmate/executors/browser/browserexecutor.py
+++ b/src/attackmate/executors/browser/browserexecutor.py
@@ -15,7 +15,11 @@ class BrowserExecutor(BaseExecutor):
         self.command_delay = 2  # TODO: what's the best way to handle delay between commands?
 
     def log_command(self, command: BrowserCommand):
-        self.logger.info(f"Executing Browser Command: {command.cmd}")
+        self.logger.info(
+            f"Executing Browser Command: {command.cmd}"
+            f"{f' {command.selector}' if command.selector else ''}"
+            f"{f' {command.url}' if command.url else ''}"
+        )
 
     def open_browser(self, command: BrowserCommand):
         if command.session and self.session_store.has_session(command.session):
@@ -52,8 +56,12 @@ class BrowserExecutor(BaseExecutor):
             if command.cmd == 'visit':
                 page.goto(command.url)
             elif command.cmd == 'click':
+                if not page.query_selector(command.selector):
+                    raise ValueError(f"Element {command.selector} not found!")
                 page.click(command.selector)
             elif command.cmd == 'type':
+                if not page.query_selector(command.selector):
+                    raise ValueError(f"Element {command.selector} not found!")
                 page.fill(command.selector, command.text)
             elif command.cmd == 'screenshot':
                 page.screenshot(path=command.screenshot_path)

--- a/src/attackmate/executors/browser/browserexecutor.py
+++ b/src/attackmate/executors/browser/browserexecutor.py
@@ -19,8 +19,6 @@ class BrowserExecutor(BaseExecutor):
         )
 
     def _exec_cmd(self, command: BrowserCommand) -> Result:
-        self.log_command(command)
-
         try:
             # Decide whether we’re using or creating a named session, or ephemeral
             if command.session:

--- a/src/attackmate/executors/browser/browserexecutor.py
+++ b/src/attackmate/executors/browser/browserexecutor.py
@@ -27,17 +27,21 @@ class BrowserExecutor(BaseExecutor):
                     return Result(f"Session '{command.session}' not found!", 1)
                 session_thread = self.session_store.get_session(command.session)
             elif command.creates_session:
-                # before creating a new session, automatically close if a session with the same name already exists
+                # before creating a new session, close if a session with the same name already exists
                 if self.session_store.has_session(command.creates_session):
                     self.logger.warning(
-                        f"Session '{command.creates_session}' already exists! Closing it before creating a new one."
+                        f"Session '{command.creates_session}' already exists! "
+                        f"Closing it before creating a new one."
                     )
                     self.session_store.close_session(command.creates_session)
-                session_thread = SessionThread(session_name=command.creates_session)
+                session_thread = SessionThread(
+                    session_name=command.creates_session,
+                    headless=command.headless or False
+                )
                 self.session_store.set_session(command.creates_session, session_thread)
             else:
                 # No session info => ephemeral
-                session_thread = SessionThread()
+                session_thread = SessionThread(headless=command.headless or False)
 
             # Execute the command
             if command.cmd == 'visit':

--- a/src/attackmate/executors/browser/browserexecutor.py
+++ b/src/attackmate/executors/browser/browserexecutor.py
@@ -27,9 +27,12 @@ class BrowserExecutor(BaseExecutor):
                     return Result(f"Session '{command.session}' not found!", 1)
                 session_thread = self.session_store.get_session(command.session)
             elif command.creates_session:
-                # We create a new session
+                # before creating a new session, automatically close if a session with the same name already exists
                 if self.session_store.has_session(command.creates_session):
-                    return Result(f"Session '{command.creates_session}' already exists!", 1)
+                    self.logger.warning(
+                        f"Session '{command.creates_session}' already exists! Closing it before creating a new one."
+                    )
+                    self.session_store.close_session(command.creates_session)
                 session_thread = SessionThread(session_name=command.creates_session)
                 self.session_store.set_session(command.creates_session, session_thread)
             else:

--- a/src/attackmate/executors/browser/browserexecutor.py
+++ b/src/attackmate/executors/browser/browserexecutor.py
@@ -1,0 +1,74 @@
+import time
+from playwright.sync_api import sync_playwright
+from attackmate.executors.baseexecutor import BaseExecutor
+from attackmate.result import Result
+from attackmate.schemas.browser import BrowserCommand
+from attackmate.executors.executor_factory import executor_factory
+from .sessionstore import BrowserSessionStore
+
+
+@executor_factory.register_executor('browser')
+class BrowserExecutor(BaseExecutor):
+    def __init__(self, pm, varstore, **kwargs):
+        super().__init__(pm, varstore, **kwargs)
+        self.session_store = BrowserSessionStore()
+        self.command_delay = 2  # TODO: what's the best way to handle delay between commands?
+
+    def log_command(self, command: BrowserCommand):
+        self.logger.info(f"Executing Browser Command: {command.cmd}")
+
+    def open_browser(self, command: BrowserCommand):
+        if command.session and self.session_store.has_session(command.session):
+            # Reuse existing session
+            return self.session_store.get_session(command.session)
+
+        # create a new session
+        playwright = sync_playwright().start()
+        browser = playwright.chromium.launch(headless=False)  # TODO: make it an option to set in playbook
+        context = browser.new_context()
+        page = context.new_page()
+
+        # store session if requested
+        if command.creates_session:
+            self.session_store.set_session(command.creates_session, browser, context, page)
+
+        return browser, context, page
+
+    def close_browser(self, browser=None, context=None, page=None):
+        if page:
+            page.close()
+        if context:
+            context.close()
+        if browser:
+            browser.close()
+
+    def _exec_cmd(self, command: BrowserCommand) -> Result:
+        browser, context, page = None, None, None
+        try:
+            # get or create browser, context, and page
+            browser, context, page = self.open_browser(command)
+
+            # Execute the command
+            if command.cmd == 'visit':
+                page.goto(command.url)
+            elif command.cmd == 'click':
+                page.click(command.selector)
+            elif command.cmd == 'type':
+                page.fill(command.selector, command.text)
+            elif command.cmd == 'screenshot':
+                page.screenshot(path=command.screenshot_path)
+            else:
+                raise ValueError(f"Unknown browser command: {command.cmd}")
+
+            # delay for visibility
+            time.sleep(self.command_delay)
+
+            return Result('Browser command executed successfully.', 0)
+
+        except Exception as e:
+            return Result(str(e), 1)
+
+        finally:
+            # close the browser resources if not using a session
+            if not command.session and not command.creates_session:
+                self.close_browser(browser, context, page)

--- a/src/attackmate/executors/browser/sessionstore.py
+++ b/src/attackmate/executors/browser/sessionstore.py
@@ -1,0 +1,30 @@
+class BrowserSessionStore:
+    def __init__(self):
+        self.store: dict[str, tuple] = {}  # maps session names to (browser, context, page)
+
+    def has_session(self, session_name: str) -> bool:
+        return session_name in self.store
+
+    def get_session(self, session_name: str) -> tuple:
+        if session_name in self.store:
+            return self.store[session_name]
+        else:
+            raise KeyError(f"Session '{session_name}' not found in BrowserSessionStore")
+
+    def set_session(self, session_name: str, browser, context, page):
+        self.store[session_name] = (browser, context, page)
+
+    def close_session(self, session_name: str):
+        if session_name in self.store:
+            browser, context, page = self.store[session_name]
+            if page:
+                page.close()
+            if context:
+                context.close()
+            if browser:
+                browser.close()
+            del self.store[session_name]
+
+    def close_all(self):
+        for session_name in list(self.store.keys()):
+            self.close_session(session_name)

--- a/src/attackmate/executors/browser/sessionstore.py
+++ b/src/attackmate/executors/browser/sessionstore.py
@@ -56,11 +56,14 @@ class SessionThread(threading.Thread):
     def _init_browser(self):
         """Initialize the browser/context/page if not already open."""
         if not self.browser:
-            self.browser = self.playwright.chromium.launch(headless=self.headless)
-            self.context = self.browser.new_context()
-            self.context.set_default_timeout(10_000)  # element operations
-            self.context.set_default_navigation_timeout(30_000)  # navigations
-            self.page = self.context.new_page()
+            try:
+                self.browser = self.playwright.chromium.launch(headless=self.headless)
+                self.context = self.browser.new_context()
+                self.context.set_default_timeout(10_000)  # element operations
+                self.context.set_default_navigation_timeout(30_000)  # navigations
+                self.page = self.context.new_page()
+            except Exception:
+                raise
 
     def _close_browser(self):
         """Close browser resources if they exist."""

--- a/src/attackmate/executors/browser/sessionstore.py
+++ b/src/attackmate/executors/browser/sessionstore.py
@@ -45,9 +45,9 @@ class SessionThread(threading.Thread):
             cmd_name, args, kwargs = command
             try:
                 result = self._handle_command(cmd_name, *args, **kwargs)
-                self.res_queue.put((False, result))
+                self.res_queue.put((result, None))
             except Exception as e:
-                self.res_queue.put((True, str(e)))
+                self.res_queue.put((None, e))
 
         # Cleanup
         self._close_browser()
@@ -110,12 +110,12 @@ class SessionThread(threading.Thread):
         This is a synchronous call from the caller’s perspective:
          - we place the command on cmd_queue,
          - then wait for the response in res_queue
-         - raise an exception if the command fails
+         - re-raise the exception to preserve traceback if it failed
         """
         self.cmd_queue.put((cmd_name, args, kwargs))
-        error, result = self.res_queue.get()
+        result, error = self.res_queue.get()
         if error:
-            raise Exception(result)
+            raise error
         return result
 
     def stop_thread(self):

--- a/src/attackmate/executors/browser/sessionstore.py
+++ b/src/attackmate/executors/browser/sessionstore.py
@@ -1,30 +1,159 @@
-class BrowserSessionStore:
-    def __init__(self):
-        self.store: dict[str, tuple] = {}  # maps session names to (browser, context, page)
+import threading
+import time
+from playwright.sync_api import sync_playwright
+from queue import Queue, Empty
 
-    def has_session(self, session_name: str) -> bool:
-        return session_name in self.store
 
-    def get_session(self, session_name: str) -> tuple:
-        if session_name in self.store:
-            return self.store[session_name]
+class SessionThread(threading.Thread):
+    """
+    A dedicated thread that manages a single Playwright browser session (browser, context, page).
+    All commands for this session are queued to make sure they run synchronously in this thread.
+    """
+    def __init__(self, session_name=None, headless=False):
+        super().__init__()
+        self.session_name = session_name
+        self.headless = headless
+        self.cmd_queue = Queue()
+        self.res_queue = Queue()
+        self.playwright = None
+        self.browser = None
+        self.context = None
+        self.page = None
+        self.stopped = False
+        self.daemon = True  # mark this thread as a daemon so it won’t block interpreter exit
+        self.start()
+
+    def run(self):
+        """
+        Main loop of the thread. It:
+          1. Starts Playwright.
+          2. Waits for commands on the cmd_queue.
+          3. Executes them.
+          4. Puts results on the res_queue.
+          5. Shuts down on stop signal.
+        """
+        self.playwright = sync_playwright().start()
+
+        while not self.stopped:
+            try:
+                command = self.cmd_queue.get(timeout=0.1)
+            except Empty:
+                continue
+
+            if command is None:
+                break  # signals that we're done
+
+            cmd_name, args, kwargs = command
+            try:
+                result = self._handle_command(cmd_name, *args, **kwargs)
+                self.res_queue.put((False, result))
+            except Exception as e:
+                self.res_queue.put((True, str(e)))
+
+        # Cleanup
+        self._close_browser()
+        self.playwright.stop()
+
+    def _init_browser(self):
+        """Initialize the browser/context/page if not already open."""
+        if not self.browser:
+            self.browser = self.playwright.chromium.launch(headless=self.headless)
+            self.context = self.browser.new_context()
+            self.page = self.context.new_page()
+
+    def _close_browser(self):
+        """Close browser resources if they exist."""
+        if self.page:
+            self.page.close()
+            self.page = None
+        if self.context:
+            self.context.close()
+            self.context = None
+        if self.browser:
+            self.browser.close()
+            self.browser = None
+
+    def _handle_command(self, cmd_name, *args, **kwargs):
+        """Executes the given command (visit, click, type, screenshot, etc.) in this thread."""
+        # Make sure we have a browser/page:
+        self._init_browser()
+
+        if cmd_name == 'visit':
+            url = kwargs['url']
+            self.page.goto(url)
+        elif cmd_name == 'click':
+            selector = kwargs['selector']
+            if not self.page.query_selector(selector):
+                raise ValueError(f"Element {selector} not found!")
+            self.page.click(selector)
+        elif cmd_name == 'type':
+            selector = kwargs['selector']
+            text = kwargs['text']
+            if not self.page.query_selector(selector):
+                raise ValueError(f"Element {selector} not found!")
+            self.page.fill(selector, text)
+        elif cmd_name == 'screenshot':
+            screenshot_path = kwargs['screenshot_path']
+            self.page.screenshot(path=screenshot_path)
         else:
-            raise KeyError(f"Session '{session_name}' not found in BrowserSessionStore")
+            raise ValueError(f"Unknown command: {cmd_name}")
 
-    def set_session(self, session_name: str, browser, context, page):
-        self.store[session_name] = (browser, context, page)
+        # If we want a built-in delay after each command, do it here
+        time.sleep(2)
 
-    def close_session(self, session_name: str):
-        if session_name in self.store:
-            browser, context, page = self.store[session_name]
-            if page:
-                page.close()
-            if context:
-                context.close()
-            if browser:
-                browser.close()
-            del self.store[session_name]
+        return 'OK'
+
+    def submit_command(self, cmd_name, *args, **kwargs):
+        """
+        Called from outside to run a command in this thread.
+        This is a synchronous call from the caller’s perspective:
+         - we place the command on cmd_queue,
+         - then wait for the response in res_queue
+         - raise an exception if the command fails
+        """
+        self.cmd_queue.put((cmd_name, args, kwargs))
+        error, result = self.res_queue.get()
+        if error:
+            raise Exception(result)
+        return result
+
+    def stop_thread(self):
+        """Signals the thread to stop and waits for it to join."""
+        self.stopped = True
+        self.cmd_queue.put(None)
+        self.join()
+
+
+class BrowserSessionStore:
+    """
+    Manages named sessions. Each named session has its own SessionThread.
+    """
+    def __init__(self):
+        self.sessions = {}
+        self.lock = threading.Lock()
+
+    def has_session(self, session_name):
+        with self.lock:
+            return session_name in self.sessions
+
+    def get_session(self, session_name):
+        with self.lock:
+            return self.sessions[session_name]
+
+    def set_session(self, session_name, session_thread):
+        with self.lock:
+            self.sessions[session_name] = session_thread
+
+    def close_session(self, session_name):
+        with self.lock:
+            if session_name in self.sessions:
+                thread = self.sessions[session_name]
+                thread.stop_thread()
+                del self.sessions[session_name]
 
     def close_all(self):
-        for session_name in list(self.store.keys()):
-            self.close_session(session_name)
+        """Stop and remove all SessionThreads."""
+        with self.lock:
+            for name, thread in list(self.sessions.items()):
+                thread.stop_thread()
+                del self.sessions[name]

--- a/src/attackmate/schemas/browser.py
+++ b/src/attackmate/schemas/browser.py
@@ -1,7 +1,9 @@
 from typing import Literal, Optional
 from attackmate.schemas.base import BaseCommand
+from attackmate.command import CommandRegistry
 
 
+@CommandRegistry.register('browser')
 class BrowserCommand(BaseCommand):
     type: Literal['browser']
     cmd: Literal['visit', 'click', 'type', 'screenshot'] = 'visit'

--- a/src/attackmate/schemas/browser.py
+++ b/src/attackmate/schemas/browser.py
@@ -18,6 +18,9 @@ class BrowserCommand(BaseCommand):
 
     @model_validator(mode='after')
     def validate_browser_command(self) -> 'BrowserCommand':
+        if self.background:
+            raise ValueError('background mode is unsupported for browser commands')
+
         if self.cmd == 'visit':
             if not self.url:
                 raise ValueError("`visit` command requires a 'url'")

--- a/src/attackmate/schemas/browser.py
+++ b/src/attackmate/schemas/browser.py
@@ -1,0 +1,13 @@
+from typing import Literal, Optional
+from attackmate.schemas.base import BaseCommand
+
+
+class BrowserCommand(BaseCommand):
+    type: Literal['browser']
+    cmd: Literal['visit', 'click', 'type', 'screenshot'] = 'visit'
+    url: Optional[str] = None
+    selector: Optional[str] = None
+    text: Optional[str] = None
+    screenshot_path: Optional[str] = None
+    creates_session: Optional[str] = None
+    session: Optional[str] = None

--- a/src/attackmate/schemas/browser.py
+++ b/src/attackmate/schemas/browser.py
@@ -1,3 +1,4 @@
+from pydantic import model_validator
 from typing import Literal, Optional
 from attackmate.schemas.base import BaseCommand
 from attackmate.command import CommandRegistry
@@ -13,3 +14,16 @@ class BrowserCommand(BaseCommand):
     screenshot_path: Optional[str] = None
     creates_session: Optional[str] = None
     session: Optional[str] = None
+
+    @model_validator(mode='after')
+    def validate_browser_command(self) -> 'BrowserCommand':
+        if self.cmd == 'visit':
+            if not self.url:
+                raise ValueError("`visit` command requires a 'url'")
+        elif self.cmd == 'type':
+            if not self.selector or not self.text:
+                raise ValueError("`type` command requires both 'selector' and 'text'")
+        elif self.cmd == 'click':
+            if not self.selector:
+                raise ValueError("`click` command requires 'selector'")
+        return self

--- a/src/attackmate/schemas/browser.py
+++ b/src/attackmate/schemas/browser.py
@@ -14,6 +14,7 @@ class BrowserCommand(BaseCommand):
     screenshot_path: Optional[str] = None
     creates_session: Optional[str] = None
     session: Optional[str] = None
+    headless: Optional[bool] = None
 
     @model_validator(mode='after')
     def validate_browser_command(self) -> 'BrowserCommand':

--- a/src/attackmate/schemas/loop.py
+++ b/src/attackmate/schemas/loop.py
@@ -28,10 +28,12 @@ from .father import FatherCommand
 from .tempfile import TempfileCommand
 from .debug import DebugCommand
 from .regex import RegExCommand
+from .browser import BrowserCommand
 
 
 Commands = List[
     Union[
+        BrowserCommand,
         ShellCommand,
         MsfModuleCommand,
         MsfSessionCommand,

--- a/src/attackmate/schemas/playbook.py
+++ b/src/attackmate/schemas/playbook.py
@@ -30,8 +30,10 @@ from .tempfile import TempfileCommand
 from .debug import DebugCommand
 from .regex import RegExCommand
 from .json import JsonCommand
+from .browser import BrowserCommand
 
 Command = Union[
+    BrowserCommand,
     ShellCommand,
     MsfModuleCommand,
     MsfSessionCommand,

--- a/test/units/test_browserexecutor.py
+++ b/test/units/test_browserexecutor.py
@@ -101,7 +101,7 @@ def test_session_thread_invalid_command(mock_playwright):
     """
     Submitting an unknown command should raise an Exception.
     """
-    thread = SessionThread(session_name='test_session')
+    thread = SessionThread(session_name='test_session', headless=True)
 
     with pytest.raises(Exception) as excinfo:
         thread.submit_command('non_existent_command')
@@ -120,7 +120,7 @@ def test_session_thread_click_selector_not_found(mock_playwright):
     mock_page = mock_playwright['mock_page']
     mock_page.query_selector.return_value = None
 
-    thread = SessionThread(session_name='test_session')
+    thread = SessionThread(session_name='test_session', headless=True)
     with pytest.raises(Exception) as excinfo:
         thread.submit_command('click', selector='#missing-button')
 

--- a/test/units/test_browserexecutor.py
+++ b/test/units/test_browserexecutor.py
@@ -149,7 +149,8 @@ def test_browser_executor_ephemeral_session(browser_executor):
     command = BrowserCommand(
         type='browser',
         cmd='visit',
-        url='http://example.org'
+        url='http://example.org',
+        headless=True
     )
     result = browser_executor._exec_cmd(command)
     assert result.returncode == 0
@@ -164,7 +165,8 @@ def test_browser_executor_named_session(browser_executor):
         type='browser',
         cmd='visit',
         url='http://example.org',
-        creates_session='my_session'
+        creates_session='my_session',
+        headless=True
     )
     result1 = browser_executor._exec_cmd(create_cmd)
     assert result1.returncode == 0
@@ -206,7 +208,8 @@ def test_browser_executor_recreate_same_session(browser_executor):
         type='browser',
         cmd='visit',
         url='http://example.org',
-        creates_session='my_session'
+        creates_session='my_session',
+        headless=True
     )
     res1 = browser_executor._exec_cmd(cmd1)
     assert res1.returncode == 0
@@ -215,7 +218,8 @@ def test_browser_executor_recreate_same_session(browser_executor):
         type='browser',
         cmd='visit',
         url='http://example.com',
-        creates_session='my_session'
+        creates_session='my_session',
+        headless=True
     )
     # This should close the old 'my_session' and create a new one
     res2 = browser_executor._exec_cmd(cmd2)

--- a/test/units/test_browserexecutor.py
+++ b/test/units/test_browserexecutor.py
@@ -124,7 +124,7 @@ def test_session_thread_click_selector_not_found(mock_playwright):
     with pytest.raises(Exception) as excinfo:
         thread.submit_command('click', selector='#missing-button')
 
-    assert 'Element #missing-button not found!' in str(excinfo.value)
+    assert 'Locator.wait_for: Timeout 10000ms exceeded' in str(excinfo.value)
 
     # Clean up
     thread.stop_thread()

--- a/test/units/test_browserexecutor.py
+++ b/test/units/test_browserexecutor.py
@@ -1,0 +1,128 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from attackmate.executors.browser.sessionstore import BrowserSessionStore, SessionThread
+
+
+@pytest.fixture
+def mock_playwright():
+    """
+    A pytest fixture that patches sync_playwright to avoid launching a real browser.
+    It yields a configurable mock.
+    """
+    with patch('playwright.sync_api.sync_playwright') as mock_sync_playwright:
+        # Create mock for the playwright object
+        mock_playwright_instance = MagicMock()
+        mock_browser = MagicMock()
+        mock_context = MagicMock()
+        mock_page = MagicMock()
+
+        mock_context.new_page.return_value = mock_page
+        mock_browser.new_context.return_value = mock_context
+        mock_playwright_instance.chromium.launch.return_value = mock_browser
+
+        # This is how the context manager start() / stop() is called:
+        mock_sync_playwright.return_value.__enter__.return_value = mock_playwright_instance
+        mock_sync_playwright.return_value.start.return_value = mock_playwright_instance
+
+        yield {
+            'mock_sync_playwright': mock_sync_playwright,
+            'mock_playwright_instance': mock_playwright_instance,
+            'mock_browser': mock_browser,
+            'mock_context': mock_context,
+            'mock_page': mock_page,
+        }
+
+
+# ----------------------------------------------------------------------------------------
+# Tests for BrowserSessionStore
+# ----------------------------------------------------------------------------------------
+
+def test_browser_session_store_creation_and_retrieval():
+    store = BrowserSessionStore()
+    assert not store.has_session('test_session'), "Expected store to not have 'test_session' initially"
+
+    # Create a dummy SessionThread (not started for real in this test)
+    thread = MagicMock(spec=SessionThread)
+    store.set_session('test_session', thread)
+    assert store.has_session('test_session'), "Expected store to have 'test_session' after setting"
+
+    retrieved = store.get_session('test_session')
+    assert retrieved is thread, 'Expected retrieved session to be the same instance stored'
+
+
+def test_browser_session_store_close_session():
+    store = BrowserSessionStore()
+    thread = MagicMock(spec=SessionThread)
+    store.set_session('test_session', thread)
+
+    store.close_session('test_session')
+    assert not store.has_session('test_session'), 'Session should have been removed after close_session'
+    thread.stop_thread.assert_called_once()
+
+
+def test_browser_session_store_close_all():
+    store = BrowserSessionStore()
+    thread1 = MagicMock(spec=SessionThread)
+    thread2 = MagicMock(spec=SessionThread)
+
+    store.set_session('session1', thread1)
+    store.set_session('session2', thread2)
+
+    store.close_all()
+    assert not store.has_session('session1')
+    assert not store.has_session('session2')
+    thread1.stop_thread.assert_called_once()
+    thread2.stop_thread.assert_called_once()
+
+
+# ----------------------------------------------------------------------------------------
+# Tests for SessionThread
+# ----------------------------------------------------------------------------------------
+
+def test_session_thread_lifecycle(mock_playwright):
+    """
+    Tests that the SessionThread starts and stops without error,
+    and that commands can be submitted.
+    """
+    thread = SessionThread(session_name='test_session', headless=True)
+
+    # Submit a command. This should go onto the queue, be processed, and return 'OK'
+    result = thread.submit_command('visit', url='http://example.org')
+    assert result == 'OK', "Expected the visit command to return 'OK'"
+
+    # Stop the thread
+    thread.stop_thread()
+    assert thread.stopped, 'Expected the thread to be marked as stopped'
+
+
+def test_session_thread_invalid_command(mock_playwright):
+    """
+    Submitting an unknown command should raise an Exception.
+    """
+    thread = SessionThread(session_name='test_session')
+
+    with pytest.raises(Exception) as excinfo:
+        thread.submit_command('non_existent_command')
+
+    assert 'Unknown command: non_existent_command' in str(excinfo.value)
+
+    # Clean up
+    thread.stop_thread()
+
+
+def test_session_thread_click_selector_not_found(mock_playwright):
+    """
+    Submitting a click command for a missing selector should raise an Exception.
+    """
+    # Make the mock page return None for query_selector => simulates "element not found"
+    mock_page = mock_playwright['mock_page']
+    mock_page.query_selector.return_value = None
+
+    thread = SessionThread(session_name='test_session')
+    with pytest.raises(Exception) as excinfo:
+        thread.submit_command('click', selector='#missing-button')
+
+    assert 'Element #missing-button not found!' in str(excinfo.value)
+
+    # Clean up
+    thread.stop_thread()


### PR DESCRIPTION
Adding a **BrowserExecutor** that uses the [Playwright API](https://playwright.dev/python/).

Summary of the updates:
* browser sessions are cached in a session store
* implemented commands: `visit`, `click`, `type`, `screenshot`
* first command must be `visit` with a `url` to create or reuse a session
* `click` and `type` require a `selector` field
* selectors use Playwright syntax — plain CSS by default, or prefix with `text=`, `xpath=`, `id=`, etc. for other engines
* unnamed sessions are ephemeral; named sessions stay alive until closed via the session store
* implemented threading, so that multiple sessions can be run parallel with a playbook
* added docs
* added unit tests

Example playbook:

```yaml
vars:
     $URL: "https://www.wikipedia.org/"

   commands:
     # Create a new named browser session called "my_session"
     - type: browser
       cmd: visit
       url: $URL
       creates_session: my_session
       # optionally we can run it in headless mode:
       # headless: true

     # Reuse the existing "my_session" to type text into an input field
     - type: browser
       cmd: type
       selector: "input[id='searchInput']"
       text: "Test"
       session: "my_session"

     # Click on the "submit" button, still reusing "my_session"
     - type: browser
       cmd: click
       selector: "button[type='submit']"
       session: "my_session"

     # Take a screenshot of the current page in the "my_session"
     - type: browser
       cmd: screenshot
       screenshot_path: "example.png"
       session: "my_session"
```