### PR TITLE
Poc grapql

### DIFF
--- a/remote_gql/README.md
+++ b/remote_gql/README.md
@@ -1,0 +1,40 @@
+# Attackmate remote execution with graphQl API
+
+## Dependencies
+pip install "strawberry-graphql[debug-server]" httpx PyYAML uvicorn stringcasepython-dotenv pydantic
+
+debug server includes uvicorn and ASGI support?
+
+types queires and mutations are defined in schema.py
+
+dependency injextion a bit tricky, how to access attackmate instance in schema?
+subclass GraphQL with get_context() method
+
+## run server
+python -m remote_gql.server
+
+## run client
+### sending whole playbook as yml
+python -m remote_gql.client playbook examples/playbook.yml
+
+### sending filepath to playbook on the attacker
+python -m remote_gql.client remote-playbook playbook.yml
+
+### shell command
+python -m remote_gql.client command shell 'echo GraphQL Test'
+python -m remote_gql.client command shell 'echo GraphQL Test' --background
+
+###  Set variable
+python -m remote_gql.client command setvar MY_VAR "hello"
+
+###  Debug
+python -m remote_gql.client command debug  "Debug this" --varstore
+
+### Example: Sleep
+python -m remote_gql.client command sleep --seconds 3
+
+### Example: Mktemp (create file)
+python -m remote_gql.client command mktemp MY_TEMP_FILE
+
+### Example: Mktemp (create dir)
+python -m remote_gql.client command mktemp MY_TEMP_DIR --make-dir

--- a/remote_gql/client.py
+++ b/remote_gql/client.py
@@ -1,0 +1,381 @@
+import httpx
+import argparse
+import yaml
+import logging
+import sys
+import json
+from typing import Dict, Any, List
+import stringcase
+
+
+# HELPER
+def parse_key_value_pairs(items: List[str] | None) -> Dict[str, str]:
+    """Helper to parse 'key=value' strings from a list into a dict."""
+    result: Dict[str, str] = {}
+    if not items:
+        return result
+    for item in items:
+        if '=' in item:
+            key, value = item.split('=', 1)
+            result[key.strip()] = value.strip()
+    return result
+
+
+def convert_keys_to_camel_case(data: Any) -> Any:
+    """Recursively converts dictionary keys from snake_case to camelCase with stringcase library."""
+    if isinstance(data, dict):
+        new_dict = {}
+        for key, value in data.items():
+            new_key = stringcase.camelcase(key)
+            new_dict[new_key] = convert_keys_to_camel_case(value)
+        return new_dict
+    elif isinstance(data, list):
+        return [convert_keys_to_camel_case(item) for item in data]
+    else:
+        return data
+
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - CLIENT - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def run_remote_playbook(client: httpx.Client, server_url: str, playbook_file: str):
+    """Sends playbook file path to the server for execution."""
+    logger.info(f"Attempting to execute remote playbook: {playbook_file}")
+
+    # GraphQL Mutation String
+    mutation = """
+        mutation ExecuteRemotePlaybook($filepath: String!) {
+            executeRemotePlaybook(playbookFilePath: $filepath) {
+                success
+                message
+                finalState {
+                    variables
+                }
+            }
+        }
+    """
+    variables = {'filepath': playbook_file}
+
+    try:
+        logger.debug(f"Sending mutation: {mutation}")
+        logger.debug(f"Variables: {variables}")
+        response = client.post(server_url, json={'query': mutation, 'variables': variables})
+        response.raise_for_status()  # Check for HTTP errors
+        data = response.json()
+        logger.info('Received response from executeRemotePlaybook.')
+        logger.debug(f"Response data: {data}")
+
+        if 'errors' in data:
+            logger.error(f"GraphQL Errors: {data['errors']}")
+            sys.exit(1)
+
+        result = data.get('data', {}).get('executeRemotePlaybook', {})
+        print('\n--- Remote Playbook Execution Result ---')
+        print(f"Success: {result.get('success')}")
+        print(f"Message: {result.get('message')}")
+        print('\n--- Final Variable Store State ---')
+        final_state = result.get('finalState', {}).get('variables', {})
+        print(yaml.dump(final_state, indent=2, default_flow_style=False))
+
+        if not result.get('success'):
+            sys.exit(1)
+
+    except httpx.RequestError as e:
+        logger.error(f"HTTP Request Error executing remote playbook: {e}")
+        sys.exit(1)
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP Status Error executing remote playbook: {e.response.status_code} - {e.response.text}")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}", exc_info=True)
+        sys.exit(1)
+
+
+def run_playbook(client: httpx.Client, server_url: str, playbook_file: str):
+    """Sends playbook YAML file to the server for execution."""
+    logger.info(f"Attempting to execute playbook: {playbook_file}")
+
+    try:
+        with open(playbook_file, 'r') as f:
+            playbook_yaml_content = f.read()
+    except FileNotFoundError:
+        logger.error(f"Error: Playbook file not found at '{playbook_file}'")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Error reading playbook file '{playbook_file}': {e}")
+        sys.exit(1)
+
+    # GraphQL Mutation String
+    mutation = """
+        mutation ExecutePlaybook($yaml: String!) {
+            executePlaybook(playbookYaml: $yaml) {
+                success
+                message
+                finalState {
+                    variables
+                }
+            }
+        }
+    """
+    variables = {'yaml': playbook_yaml_content}
+
+    try:
+        logger.debug(f"Sending mutation: {mutation}")
+        logger.debug(f"Variables: {variables}")
+        response = client.post(server_url, json={'query': mutation, 'variables': variables})
+        response.raise_for_status()  # Check for HTTP errors
+        data = response.json()
+        logger.info('Received response from executePlaybook.')
+        logger.debug(f"Response data: {data}")
+
+        if 'errors' in data:
+            logger.error(f"GraphQL Errors: {data['errors']}")
+            sys.exit(1)
+
+        result = data.get('data', {}).get('executePlaybook', {})
+        print('\n--- Playbook Execution Result ---')
+        print(f"Success: {result.get('success')}")
+        print(f"Message: {result.get('message')}")
+        print('\n--- Final Variable Store State ---')
+        final_state = result.get('finalState', {}).get('variables', {})
+        print(yaml.dump(final_state, indent=2, default_flow_style=False))
+
+        if not result.get('success'):
+            sys.exit(1)
+
+    except httpx.RequestError as e:
+        logger.error(f"HTTP Request Error executing playbook: {e}")
+        sys.exit(1)
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP Status Error executing playbook: {e.response.status_code} - {e.response.text}")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}", exc_info=True)
+        sys.exit(1)
+
+
+def run_command(client: httpx.Client, server_url: str, args):
+    """Sends a single command to the server for execution."""
+    logger.info(f"Attempting to execute command: type='{args.command_type}'")
+
+    # onstruct the  input dictionary from args
+    command_input: Dict[str, Any] = {'type': args.command_type}
+
+    # Add cmd, sometimesbased on type (like sleep, has default cmd "sleep" in pydantic model
+
+    primary_cmd_arg = None
+    if hasattr(args, 'cmd'):
+        primary_cmd_arg = args.cmd
+    # Add elif for other commands here that dont have cmd? or default in pydantic model used anyways (likle sleep)
+
+    if primary_cmd_arg is not None:
+        command_input['cmd'] = primary_cmd_arg
+
+    # Add common fields if they exist in args and are not None
+    common_fields = ['only_if', 'error_if', 'error_if_not', 'loop_if', 'loop_if_not',
+                     'loop_count', 'exit_on_error', 'save', 'background', 'kill_on_exit']
+    for field in common_fields:
+        if hasattr(args, field):
+            value = getattr(args, field)
+            if value is not None:
+                # Convert types if necessary (e.g., loop_count to string)
+                if field == 'loop_count':
+                    value = str(value)
+                command_input[field] = value
+
+    # Add metadata
+    if hasattr(args, 'metadata') and args.metadata:
+        command_input['metadata'] = parse_key_value_pairs(args.metadata)
+
+    # Default assumption: positional arg is 'cmd' if it exists
+    if hasattr(args, 'cmd') and args.cmd is not None:
+        command_input['cmd'] = args.cmd
+    # Add specific fields based on command_type
+    # Ensure arg names match the field names in the CommandInput Strawberry type
+    specific_fields = []
+    if args.command_type == 'shell':
+        specific_fields = ['interactive', 'creates_session', 'session', 'command_timeout', 'read', 'command_shell', 'bin']
+        if hasattr(args, 'command_timeout') and args.command_timeout is not None:
+            command_input['command_timeout'] = str(args.command_timeout)  # String number
+    elif args.command_type == 'sleep':
+        specific_fields = ['min_sec', 'seconds', 'random']
+        if hasattr(args, 'min_sec') and args.min_sec is not None:
+            command_input['min_sec'] = str(args.min_sec)  # String number
+        if hasattr(args, 'seconds') and args.seconds is not None:
+            command_input['seconds'] = str(args.seconds)    # String number
+    elif args.command_type == 'debug':
+        specific_fields = ['varstore', 'exit', 'wait_for_key']
+    elif args.command_type == 'setvar':
+        specific_fields = ['variable', 'encoder']
+        command_input['variable'] = args.variable
+    elif args.command_type == 'mktemp':
+        specific_fields = ['make_dir', 'variable']
+        command_input['variable'] = args.variable
+    #  SPECIFIC FIELDS FOR OTHER COMMANDS HERE
+
+    for field in specific_fields:
+        if hasattr(args, field):
+            value = getattr(args, field)
+            if value is not None:
+                command_input[field] = value
+
+    # GraphQL Mutation String
+    mutation = """
+        mutation ExecuteCommand($cmdInput: CommandInput!) {
+            executeCommand(command: $cmdInput) {
+                result {
+                    success
+                    stdout
+                    returncode
+                    errorMessage
+                }
+                state {
+                    variables
+                }
+            }
+        }
+    """
+    # convert commandInput to camelCase
+
+    variables = {'cmdInput': convert_keys_to_camel_case(command_input)}
+
+    try:
+        logger.debug(f"Sending mutation: {mutation}")
+        logger.debug(f"Variables: {json.dumps(variables, indent=2)}")
+        response = client.post(server_url, json={'query': mutation, 'variables': variables})
+        response.raise_for_status()
+        data = response.json()
+        logger.info('Received response from executeCommand.')
+        logger.debug(f"Response data: {data}")
+
+        if 'errors' in data:
+            logger.error(f"GraphQL Errors: {data['errors']}")
+            sys.exit(1)
+
+        exec_response = data.get('data', {}).get('executeCommand', {})
+        result = exec_response.get('result', {})
+        state = exec_response.get('state', {}).get('variables', {})
+
+        print('\n--- Command Execution Result ---')
+        print(f"Success: {result.get('success')}")
+        print(f"Return Code: {result.get('returncode')}")
+        print(f"Stdout:\n{result.get('stdout')}")
+        if result.get('errorMessage'):
+            print(f"Error Message: {result.get('errorMessage')}")
+
+        print('\n--- Updated Variable Store State ---')
+        print(yaml.dump(state, indent=2, default_flow_style=False))
+
+        is_background = hasattr(args, 'background') and args.background is True
+        # Exit with error if GraphQL reports failure OR command failed (and not backgrounded)
+        if not result.get('success') or (result.get('returncode') != 0 and not is_background):
+            sys.exit(1)
+
+    except httpx.RequestError as e:
+        logger.error(f"HTTP Request Error executing command: {e}")
+        sys.exit(1)
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP Status Error executing command: {e.response.status_code} - {e.response.text}")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Unexpected error executing command: {e}", exc_info=True)
+        sys.exit(1)
+
+
+#  TODO add more verbose help messages
+def main():
+    parser = argparse.ArgumentParser(description='AttackMate GraphQL Client')
+    parser.add_argument('--server-url', default='http://localhost:8000/graphql', help='server endpoint URL')
+    subparsers = parser.add_subparsers(dest='mode', required=True, help='Execution mode')
+
+    # Playbook Subparser
+    parser_playbook = subparsers.add_parser('playbook', help='Execute an entire playbook from a YAML file')
+    parser_playbook.add_argument('playbook_file', help='Path to the playbook YAML file')
+
+    # Remote Playbook Subparser
+    parser_remote_playbook = subparsers.add_parser('remote-playbook', help='Execute an entire playbook existing on the remote machine')
+    parser_remote_playbook.add_argument('playbook_file', help='Path to the playbook file on the remote machine')
+
+    #  Command Subparser
+    parser_command = subparsers.add_parser('command', help='Execute a single command')
+    command_subparsers = parser_command.add_subparsers(dest='command_type', required=True, help='Specific command type')
+
+    #  Define Common Arguments
+    common_args_parser = argparse.ArgumentParser(add_help=False)
+    common_args_parser.add_argument('--only-if', help='Conditional execution string')
+    common_args_parser.add_argument('--error-if', help='Regex pattern for error on match')
+    common_args_parser.add_argument('--error-if-not', help='Regex pattern for error if no match')
+    common_args_parser.add_argument('--loop-if', help='Regex pattern to loop on match')
+    common_args_parser.add_argument('--loop-if-not', help='Regex pattern to loop if no match')
+    common_args_parser.add_argument('--loop-count', type=int, help='Maximum loop iterations')
+    common_args_parser.add_argument('--exit-on-error', action=argparse.BooleanOptionalAction, help='Exit if command return code is non-zero')
+    common_args_parser.add_argument('--save', help='File path to save command stdout')
+    common_args_parser.add_argument('--background', action=argparse.BooleanOptionalAction, help='Run command in the background')
+    common_args_parser.add_argument('--kill-on-exit', action=argparse.BooleanOptionalAction, help='Kill process on server exit')
+    common_args_parser.add_argument('--metadata', action='append', help='Metadata key=value pair (repeatable)')
+
+    # Subparsers for  Commands
+    # Shell
+    parser_shell = command_subparsers.add_parser('shell', help='Execute shell command', parents=[common_args_parser])
+    parser_shell.add_argument('cmd', help='The command to execute')
+    parser_shell.add_argument('--interactive', action=argparse.BooleanOptionalAction)
+    parser_shell.add_argument('--creates-session', help='Name of shell session to create')
+    parser_shell.add_argument('--session', help='Name of existing shell session to use')
+    parser_shell.add_argument('--command-timeout', type=int)
+    parser_shell.add_argument('--read', action=argparse.BooleanOptionalAction, default=True)
+    parser_shell.add_argument('--command-shell', help='Shell path')
+    parser_shell.add_argument('--bin', action=argparse.BooleanOptionalAction)
+
+    # Sleep
+    parser_sleep = command_subparsers.add_parser('sleep', help='Pause execution', parents=[common_args_parser])
+    parser_sleep.add_argument('--seconds', type=str)
+    parser_sleep.add_argument('--min-sec', type=str)
+    parser_sleep.add_argument('--random', action=argparse.BooleanOptionalAction)
+
+    # Debug
+    parser_debug = command_subparsers.add_parser('debug', help='Debug output or pause', parents=[common_args_parser])
+    parser_debug.add_argument('cmd', help='Message to print')
+    parser_debug.add_argument('--varstore', action=argparse.BooleanOptionalAction)
+    parser_debug.add_argument('--exit', action=argparse.BooleanOptionalAction)
+    parser_debug.add_argument('--wait-for-key', action=argparse.BooleanOptionalAction)
+
+    # SetVar
+    parser_setvar = command_subparsers.add_parser('setvar', help='Set a variable', parents=[common_args_parser])
+    parser_setvar.add_argument('cmd', help='Value to assign')
+    parser_setvar.add_argument('variable', help='Name of the varibale to set')
+    parser_setvar.add_argument('--encoder', help='Encoder to use')
+
+    # Mktemp (Tempfile)
+    parser_mktemp = command_subparsers.add_parser('mktemp', help='Create temporary file/directory', parents=[common_args_parser])
+    parser_mktemp.add_argument('variable', help='Variable name to store the path')
+    parser_mktemp.add_argument('--make-dir', action='store_true', help='Create a directory instead of a file')
+
+    #  ADD SUBPARSERS FOR OTHER COMMANDS HERE
+
+    args = parser.parse_args()
+
+    #  Create HTTP Client
+    timeout = httpx.Timeout(10.0, connect=5.0, read=60.0)
+    client = httpx.Client(timeout=timeout)
+
+    #  Execute
+    try:
+        if args.mode == 'remote-playbook':
+            run_remote_playbook(client, args.server_url, args.playbook_file)
+        if args.mode == 'playbook':
+            run_playbook(client, args.server_url, args.playbook_file)
+        elif args.mode == 'command':
+            if hasattr(args, 'command_type') and args.command_type:
+                run_command(client, args.server_url, args)
+            else:
+                logger.error('Internal error: Command mode selected but no command type subparser matched.')
+                parser.print_help()
+                sys.exit(1)
+    finally:
+        client.close()
+        logger.info('HTTP client closed.')
+
+
+if __name__ == '__main__':
+    main()

--- a/remote_gql/schema.py
+++ b/remote_gql/schema.py
@@ -1,0 +1,323 @@
+import sys
+import strawberry
+import yaml
+import logging
+from typing import Optional, Dict, Any
+
+# for flexible variable values
+from strawberry.scalars import JSON
+from strawberry.types import Info
+
+from attackmate.attackmate import AttackMate
+from attackmate.schemas.playbook import Playbook
+from attackmate.command import CommandRegistry
+from attackmate.variablestore import VariableStore
+from attackmate.execexception import ExecException
+from pydantic import ValidationError
+
+
+logger = logging.getLogger(__name__)
+
+
+@strawberry.type
+class CommandResult:
+    """Result of a single command execution."""
+    success: bool
+    stdout: Optional[str] = None
+    returncode: Optional[int] = None
+    error_message: Optional[str] = None
+
+
+@strawberry.type
+class VariableStoreState:
+    """Represents the state of the AttackMate variable store."""
+    # JSON scalar for the  the map[string, Any]
+    variables: JSON  # {'var1': 'value', 'list1': ['a', 'b']} etc.
+
+
+@strawberry.type
+class ExecutionResponse:
+    """Response containing command result and updated state."""
+    result: CommandResult
+    state: VariableStoreState
+
+
+@strawberry.type
+class PlaybookExecutionResponse:
+    """Response after executing a full playbook."""
+    success: bool
+    message: str
+    final_state: VariableStoreState
+
+
+# Input Type for Commands
+# ALL fields from ALL supported command Pydantic models  Optional
+
+@strawberry.input
+class CommandInput:
+    """Input for executing a single command."""
+    # Common fields (mapping toBaseCommand)
+    type: str
+    cmd: Optional[str] = None
+    only_if: Optional[str] = None
+    error_if: Optional[str] = None
+    error_if_not: Optional[str] = None
+    loop_if: Optional[str] = None
+    loop_if_not: Optional[str] = None
+    loop_count: Optional[str] = None  # actually StringNumber
+    exit_on_error: Optional[bool] = None
+    save: Optional[str] = None
+    background: Optional[bool] = None
+    kill_on_exit: Optional[bool] = None
+    metadata: Optional[JSON] = None  # actually dict
+
+    # Specific Fields
+
+    # ShellCommand fields
+    interactive: Optional[bool] = None
+    creates_session: Optional[str] = None
+    session: Optional[str] = None
+    command_timeout: Optional[str] = None   # actually StringNumber
+    read: Optional[bool] = None
+    command_shell: Optional[str] = None
+    bin: Optional[bool] = None
+
+    # SleepCommand fields
+    min_sec: Optional[str] = None  # actually StringNumber
+    seconds: Optional[str] = None   # actually StringNumber
+    random: Optional[bool] = None
+
+    # DebugCommand fields
+    varstore: Optional[bool] = None
+    exit: Optional[bool] = None
+    wait_for_key: Optional[bool] = None
+
+    # SetVarCommand fields
+    variable: Optional[str] = None
+    encoder: Optional[str] = None
+
+    # TempfileCommand (mktemp) fields
+    make_dir: Optional[bool] = None  # Use a boolean flag for cmd='dir' ?
+    # variable: Optional[str] = None already defined in setvar
+
+# TODO what about variable name conflicts?
+
+# HELPERS
+
+
+# --- Helper Function ---
+def _varstore_to_gql_state(varstore: VariableStore) -> VariableStoreState:
+    """Converts AttackMate VariableStore to GraphQL VariableStoreState."""
+    combined_vars: Dict[str, Any] = {}
+    combined_vars.update(varstore.variables)
+    combined_vars.update(varstore.lists)
+    return VariableStoreState(variables=combined_vars)  # type: ignore[call-arg]
+
+# RESOLVERS
+
+
+@strawberry.type
+class Query:
+
+    @strawberry.field
+    def hello(self) -> str:
+        return 'API is running!'
+
+    @strawberry.field
+    def get_state(self, info: Info) -> VariableStoreState:
+        """Gets the current variable store state from the context."""
+        # Access dependencies from context
+        attackmate_instance = info.context.get('attackmate_instance')
+        if not attackmate_instance:
+            raise Exception('AttackMate instance not found')
+        logger.info('Query: get_state received.')
+        return _varstore_to_gql_state(attackmate_instance.varstore)
+
+
+# PLAYBOOK EXECUTION
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def execute_playbook(self, info: Info, playbook_yaml: str, initial_state: Optional[JSON] = None) -> PlaybookExecutionResponse:
+        """Executes an entire playbook provided as YAML."""
+        logger.info('Mutation: execute_playbook received.')
+        attackmate_config = info.context.get('attackmate_config')
+        if not attackmate_config:
+            raise Exception('AttackMate config not found in context')
+        try:
+            playbook_dict = yaml.safe_load(playbook_yaml)
+            if not playbook_dict:
+                raise ValueError('Empty playbook YAML')
+            playbook = Playbook.model_validate(playbook_dict)
+
+            # Prepare initial vars if provided
+            initial_vars_dict: Dict[str, Any] = {}
+            if initial_state:
+                if isinstance(initial_state, dict):
+                    initial_vars_dict = initial_state
+                else:
+                    logger.warning('initial_state was not a valid dictionary, ignoring.')
+
+            # transient AttackMate instance for playbook run
+            logger.info('Creating transient AttackMate instance for playbook execution...')
+            am_instance = AttackMate(playbook=playbook, config=attackmate_config, varstore=initial_vars_dict)
+            logger.info('Transient AttackMate instance created.')
+
+            # Execute the playbook
+            return_code = am_instance.main()
+            final_varstore = am_instance.varstore
+            am_instance.clean_session_stores()
+            logger.info(f"Playbook execution finished with code: {return_code}")
+
+            return PlaybookExecutionResponse(
+                success=(return_code == 0),
+                message='Playbook execution finished.',
+                final_state=_varstore_to_gql_state(final_varstore)
+            )  # type: ignore[call-arg]
+
+        except (yaml.YAMLError, ValidationError, ValueError) as e:
+            logger.error(f"Error processing playbook: {e}", exc_info=True)
+            return PlaybookExecutionResponse(success=False, message=f"Playbook Error: {e}", final_state=VariableStoreState(variables={}))  # type: ignore[call-arg]
+        except Exception as e:
+            logger.error(f"Unexpected error during playbook execution: {e}", exc_info=True)
+            return PlaybookExecutionResponse(success=False, message=f"Server Error: {e}", final_state=VariableStoreState(variables={}))  # type: ignore[call-arg]
+
+    @strawberry.mutation
+    def execute_remote_playbook(self, info: Info, playbook_file_path: str, initial_state: Optional[JSON] = None) -> PlaybookExecutionResponse:
+        """Executes an entire playbook provided as YAML."""
+        logger.info('Mutation: execute_remote_playbook received.')
+        attackmate_config = info.context.get('attackmate_config')
+        if not attackmate_config:
+            raise Exception('AttackMate config not found in context')
+        try:
+            with open(playbook_file_path, 'r') as f:
+                playbook_yaml_content = f.read()
+        except FileNotFoundError:
+            logger.error(f"Error: Playbook file not found at '{playbook_file_path}'")
+            sys.exit(1)
+        except Exception as e:
+            logger.error(f"Error reading playbook file '{playbook_file_path}': {e}")
+            sys.exit(1)
+        try:
+            playbook_dict = yaml.safe_load(playbook_yaml_content)
+            if not playbook_dict:
+                raise ValueError('Empty playbook YAML')
+            playbook = Playbook.model_validate(playbook_dict)
+            # Prepare initial vars if provided
+            initial_vars_dict: Dict[str, Any] = {}
+            if initial_state:
+                if isinstance(initial_state, dict):
+                    initial_vars_dict = initial_state
+                else:
+                    logger.warning('initial_state was not a valid dictionary, ignoring.')
+            # transient AttackMate instance for playbook run
+            logger.info('Creating transient AttackMate instance for playbook execution...')
+            am_instance = AttackMate(playbook=playbook, config=attackmate_config, varstore=initial_vars_dict)
+            logger.info('Transient AttackMate instance created.')
+            # Execute the playbook
+            return_code = am_instance.main()
+            final_varstore = am_instance.varstore
+            am_instance.clean_session_stores()
+            logger.info(f"Playbook execution finished with code: {return_code}")
+            return PlaybookExecutionResponse(
+                success=(return_code == 0),
+                message='Playbook execution finished.',
+                final_state=_varstore_to_gql_state(final_varstore)
+            )  # type: ignore[call-arg]
+        except (yaml.YAMLError, ValidationError, ValueError) as e:
+            logger.error(f"Error processing playbook: {e}", exc_info=True)
+            return PlaybookExecutionResponse(success=False, message=f"Playbook Error: {e}", final_state=VariableStoreState(variables={}))  # type: ignore[call-arg]
+        except Exception as e:
+            logger.error(f"Unexpected error during playbook execution: {e}", exc_info=True)
+            return PlaybookExecutionResponse(success=False, message=f"Server Error: {e}", final_state=VariableStoreState(variables={}))  # type: ignore[call-arg]
+
+# SINGLE COMMAND EXECUTION
+
+    @strawberry.mutation
+    def execute_command(self, info: Info, command: CommandInput) -> ExecutionResponse:
+        """Executes a single command using the persistent server state."""
+        logger.info(f"Mutation: execute_command received for type: {command.type}")
+        attackmate_instance = info.context.get('attackmate_instance')
+        if not attackmate_instance:
+            err_msg = 'AttackMate instance not available in context.'
+            logger.error(err_msg)
+            return ExecutionResponse(result=CommandResult(success=False, error_message=err_msg, returncode=-1), state=VariableStoreState(variables={}))  # type: ignore[call-arg]
+        pydantic_cmd = None
+
+        try:
+            # Strawberry Input to Python Dict
+            command_dict = {
+                k: v for k, v in strawberry.asdict(command).items() if v is not None
+            }
+
+            # Handle specific input mappings
+            command_type = command_dict.get('type')
+            if not command_type:
+                raise ValueError("'type' field is required in CommandInput.")
+
+            # Special handling for mktemp (tempfile) type mapping
+            if command_type == 'mktemp':
+                command_dict['type'] = 'mktemp'
+                # Map make_dir flag to Pydantic 'cmd' field for TempfileCommand
+                if command_dict.pop('make_dir', False):
+                    command_dict['cmd'] = 'dir'
+                else:
+                    # default is file
+                    pass
+
+            # get Pydantic Class via CommandRegistry
+            pydantic_type_key = command_dict['type']
+            pydantic_cmd_key = command_dict.get('cmd')
+
+            CommandClass = CommandRegistry.get_command_class(pydantic_type_key, pydantic_cmd_key)
+            if CommandClass is None and pydantic_cmd_key:  # Try without cmd if specific lookup failed
+                CommandClass = CommandRegistry.get_command_class(pydantic_type_key)
+
+            if CommandClass is None:
+                raise ValueError(f"Could not find registered Pydantic model for type='{pydantic_type_key}', cmd='{pydantic_cmd_key}'")
+
+            # Validate
+            logger.debug(f"Data for Pydantic validation ({CommandClass.__name__}): {command_dict}")
+            pydantic_cmd = CommandClass.model_validate(command_dict)
+            logger.info(f"Converted input to Pydantic: {type(pydantic_cmd).__name__}")
+
+            # Execute the command
+            logger.info('Calling attackmate_instance.run_command')
+            attackmate_result = attackmate_instance.run_command(pydantic_cmd)
+            logger.info(f"Returned from attackmate_instance.run_command. Result: {attackmate_result!r}")
+
+            # Prepare result
+            gql_result = CommandResult(
+                 success=True,
+                 stdout=str(attackmate_result.stdout) if attackmate_result.stdout is not None else None,
+                 returncode=attackmate_result.returncode,
+                 error_message=None
+            )  # type: ignore[call-arg]
+            # Special case for background/skipped commands
+            if attackmate_result.stdout is None and attackmate_result.returncode is None:
+                gql_result.stdout = 'Command likely backgrounded or skipped.'
+                gql_result.returncode = 0
+
+        except (ExecException, SystemExit) as e:
+            logger.error(f"AttackMate execution error: {e}", exc_info=True)
+            gql_result = CommandResult(
+                success=False,
+                stdout=None,
+                returncode=e.code if isinstance(e, SystemExit) and isinstance(e.code, int) else 1,
+                error_message=f"Execution Error: {e}"
+            )  # type: ignore[call-arg]
+        except (ValidationError, ValueError) as e:
+            logger.error(f"Input validation/conversion error: {e}", exc_info=True)
+            gql_result = CommandResult(success=False, returncode=-1, error_message=f"Input Error: {e}")  # type: ignore[call-arg]
+        except Exception as e:
+            logger.error(f"Unexpected server error: {e}", exc_info=True)
+            gql_result = CommandResult(success=False, returncode=-1, error_message=f"Server Error: {e}")  # type: ignore[call-arg]
+
+        # Get final state from persistent instance
+        final_gql_state = _varstore_to_gql_state(attackmate_instance.varstore)
+
+        return ExecutionResponse(result=gql_result, state=final_gql_state)  # type: ignore[call-arg]
+
+
+# Pass instances of the resolver classes to Schema
+schema = strawberry.Schema(query=Query(), mutation=Mutation())

--- a/remote_gql/server.py
+++ b/remote_gql/server.py
@@ -80,7 +80,8 @@ if __name__ == '__main__':
     app = create_app()
     logger.info('Starting Uvicorn server...')
     try:
-        uvicorn.run(app, host='0.0.0.0', port=8000, log_level='info')
+        uvicorn.run(app, host='0.0.0.0', port=8000, log_level='info', log_config=None)
+        # Disabled default logging to have attackmate.log, attackmate.json etc. but maybe uvicorn logging needed
 
     finally:
         logger.info('Uvicorn server stopped. Performing application cleanup.')

--- a/remote_gql/server.py
+++ b/remote_gql/server.py
@@ -1,0 +1,87 @@
+import uvicorn
+import logging
+import sys
+from typing import Optional, Union
+from strawberry.asgi import GraphQL
+from starlette.requests import Request
+from starlette.websockets import WebSocket
+from starlette.responses import Response
+
+from .schema import schema
+from src.attackmate.attackmate import AttackMate
+from src.attackmate.playbook_parser import parse_config
+from src.attackmate.logging_setup import initialize_logger, initialize_output_logger, initialize_json_logger
+from src.attackmate.schemas.config import Config
+
+
+attackmate_instance: Optional[AttackMate] = None
+attackmate_config: Optional[Config] = None
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+class AttackMateGraphQL(GraphQL):
+    async def get_context(
+        self, request: Union[Request, WebSocket], response: Optional[Union[Response, WebSocket]] = None
+    ):
+        # This provides the context for each request
+        # access the global instances here
+        if not attackmate_instance or not attackmate_config:
+            logger.error('AttackMate instance or config not initialized before context creation!')
+            # exception handling
+            return None
+        return {
+            'request': request,
+            'response': response,
+            'attackmate_instance': attackmate_instance,
+            'attackmate_config': attackmate_config,
+        }
+
+
+def create_app():
+    global attackmate_instance, attackmate_config
+
+    # Loggers
+    initialize_logger(debug=True, append_logs=False)
+    initialize_output_logger(debug=True, append_logs=False)
+    initialize_json_logger(json=True, append_logs=False)
+    logger.info('AttackMate loggers initialized.')
+
+    # Config
+    attackmate_config = parse_config(config_file=None, logger=logger)
+    logger.info('AttackMate configuration loaded.')
+
+    #  persistent AttackMate Instance
+    logger.info('Creating persistent AttackMate instance...')
+    # Pass empty initial playbook/vars
+    attackmate_instance = AttackMate(playbook=None, config=attackmate_config, varstore=None)
+    logger.info('Persistent AttackMate instance created.')
+
+    graphql_app = AttackMateGraphQL(schema, graphql_ide=True)
+
+    return graphql_app
+
+
+def shutdown():
+    logger.warning('Server shutting down...')
+    if attackmate_instance:
+        logger.info('Cleaning up AttackMate instance...')
+        try:
+            attackmate_instance.clean_session_stores()
+            logger.info('AttackMate cleaup finished.')
+        except Exception as e:
+            logger.error(f"Error during AttackMate cleanup: {e}", exc_info=True)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+
+    app = create_app()
+    logger.info('Starting Uvicorn server...')
+    try:
+        uvicorn.run(app, host='0.0.0.0', port=8000, log_level='info')
+
+    finally:
+        logger.info('Uvicorn server stopped. Performing application cleanup.')
+        shutdown()


### PR DESCRIPTION
# Attackmate remote execution with graphql API

## Dependencies
``pip install "strawberry-graphql[debug-server]" httpx PyYAML uvicorn stringcase``

types queires and mutations are defined in schema.py

dependency injection a bit tricky, how to access attackmate instance in schema?
subclass GraphQL with ``get_context()`` method

## run server
``python -m remote_gql.server``

## run client
### sending whole playbook as yml
``python -m remote_gql.client playbook examples/playbook.yml``

### sending filepath to playbook present on the attacker
``python -m remote_gql.client remote-playbook playbook.yml``

### shell command
``python -m remote_gql.client command shell 'echo GraphQL Test'``
``python -m remote_gql.client command shell 'echo GraphQL Test' --background``

###  Set variable
``python -m remote_gql.client command setvar MY_VAR "hello"``

###  Debug
``python -m remote_gql.client command debug  "Debug this" --varstore``

## Command with metadata as key-value pairs
``python -m remote_gql.client command debug  "Debug this" --varstore --metadata "tactic=reconnaissance" --metadata "technique=some_technique``

### Sleep
``python -m remote_gql.client command sleep --seconds 3``

### Mktemp (create file)
``python -m remote_gql.client command mktemp MY_TEMP_FILE``

###  Mktemp (create dir)
``python -m remote_gql.client command mktemp MY_TEMP_DIR --make-dir``
