### PR TITLE
add command_delay to config

### DIFF
--- a/docs/source/configuration/command_config.rst
+++ b/docs/source/configuration/command_config.rst
@@ -2,13 +2,15 @@
 cmd_config
 ==========
 
-Stores global variables for command options. These are settings for **all** commands.
+Stores global variables for command options.
+These are settings for **all** commands.
 
 .. code-block:: yaml
 
    ###
    cmd_config:
      loop_sleep: 5
+     command_delay: 0
 
 .. confval:: loop_sleep
 
@@ -19,3 +21,11 @@ Stores global variables for command options. These are settings for **all** comm
 
    :type: int
    :default: 5
+
+.. confval:: command_delay
+
+   This delay in seconds is applied to all commands in the playbook.
+   It is not applied to debug, setvar and sleep commands.
+
+   :type: float
+   :default: 0

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -25,6 +25,7 @@ sliver and metasploit:
    ###
    cmd_config:
      loop_sleep: 5
+     command_delay: 0
 
    msf_config:
      password: securepassword

--- a/src/attackmate/schemas/config.py
+++ b/src/attackmate/schemas/config.py
@@ -16,9 +16,10 @@ class MsfConfig(BaseModel):
 
 class CommandConfig(BaseModel):
     loop_sleep: int = 5
+    command_delay: float = 0
 
 
 class Config(BaseModel):
     sliver_config: SliverConfig = SliverConfig(config_file=None)
     msf_config: MsfConfig = MsfConfig(password=None)
-    cmd_config: CommandConfig = CommandConfig(loop_sleep=5)
+    cmd_config: CommandConfig = CommandConfig(loop_sleep=5, command_delay=0)


### PR DESCRIPTION
this PR relates to issue #170 

adds a config variable `command_delay` to `CommandConfig` schema, default is 0.
this delay is applies in the` run_commands()` function of `AttackMate` for all commands except debug, setvar and sleep