### PR TITLE
improve errors for playbook parsing

### DIFF
--- a/src/attackmate/playbook_parser.py
+++ b/src/attackmate/playbook_parser.py
@@ -136,7 +136,21 @@ def parse_playbook(playbook_file: str, logger: logging.Logger) -> Playbook:
     except OSError:
         logger.error(f'Error: Could not open playbook file {target_file}')
         exit(1)
-    except ValidationError:
+    except ValidationError as e:
         logger.error(f'A Validation error occured when parsing playbook file {playbook_file}')
+        for error in e.errors():
+            if error['type'] == 'missing':
+                logger.error(
+                    f'Missing field in {error["loc"][-2]} command: {error["loc"][-1]} - {error["msg"]}'
+                )
+            elif error['type'] == 'literal_error':
+                logger.error(
+                    f'Invalid value in {error["loc"][-2]} command: {error["loc"][-1]} - {error["msg"]}'
+                )
+            elif error['type'] == 'value_error':
+                logger.error(
+                    f'Value error in command {int(error["loc"][-2]) + 1}: '
+                    f'{error["loc"][-1]} - {error["msg"]}'
+                )
         logger.error(traceback.format_exc())
         exit(1)

--- a/src/attackmate/schemas/command_types.py
+++ b/src/attackmate/schemas/command_types.py
@@ -1,14 +1,18 @@
 
 
-from typing import List, TypeAlias, Union
+from typing import List, Annotated, TypeAlias, Union
+from pydantic import Field
 from attackmate.schemas.command_subtypes import RemotelyExecutableCommand
 from attackmate.schemas.remote import AttackMateRemoteCommand
 
 
-Command: TypeAlias = Union[
+Command: TypeAlias = Annotated[
+    Union[
         RemotelyExecutableCommand,
         AttackMateRemoteCommand
-    ]
+    ],
+    Field(discriminator='type'),
+]
 
 
 Commands:  TypeAlias = List[Command]


### PR DESCRIPTION
relates to issue #154 

- makes` Command` a discriminated Union (to reduce noise when type checking, otherwise pydantic checks all members of the union)
-  add concise error messages for the most common parsing errors, missing_field, literal_error and value_error (still keep logging the error traceback)
Demo:
<img width="1213" height="668" alt="image" src="https://github.com/user-attachments/assets/7a57f7ae-3029-43ef-8111-d12ed6828547" />



