### PR TITLE
Fixed an issue with numeric metasploit-options

### DIFF
--- a/src/attackmate/executors/metasploit/msfexecutor.py
+++ b/src/attackmate/executors/metasploit/msfexecutor.py
@@ -88,6 +88,7 @@ class MsfModuleExecutor(BaseExecutor):
             for option, setting in command.options.items():
                 if setting.isnumeric():
                     exploit[option] = int(setting)
+                    continue
                 if setting.lower() in ['true', 'false', '1', '0', 'y', 'n', 'yes', 'no']:
                     exploit[option] = CmdVars.variable_to_bool(option, setting)
                 else:


### PR DESCRIPTION
Currently numeric metasploit-options should be automatically translated to integers. But after translating them to integers the next line tries .lower() them. This leads to errors, since integers can't be lowered as strings.