### PR TITLE
calculate sleep time in computed field

### DIFF
--- a/src/attackmate/executors/common/sleepexecutor.py
+++ b/src/attackmate/executors/common/sleepexecutor.py
@@ -1,8 +1,6 @@
 import time
-from random import randint
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.result import Result
-from attackmate.executors.features.cmdvars import CmdVars
 from attackmate.variablestore import VariableStore
 from attackmate.processmanager import ProcessManager
 from attackmate.executors.executor_factory import executor_factory
@@ -12,20 +10,10 @@ from attackmate.executors.executor_factory import executor_factory
 class SleepExecutor(BaseExecutor):
     def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore):
         super().__init__(pm, varstore, cmdconfig)
-        self.sleep_time = None
-
-    def set_sleeptime(self, command):
-        self.sleep_time = CmdVars.variable_to_int('seconds', command.seconds)
-        if command.random:
-            self.sleep_time = randint(
-                CmdVars.variable_to_int('min_sec', command.min_sec),  # nosec
-                CmdVars.variable_to_int('seconds', command.seconds),
-            )  # nosec
 
     def log_command(self, command):
-        self.set_sleeptime(command)
-        self.logger.info(f'Sleeping {self.sleep_time} seconds')
+        self.logger.info(f'Sleeping {command.sleep_time} seconds')
 
     def _exec_cmd(self, command):
-        time.sleep(self.sleep_time)
+        time.sleep(command.sleep_time)
         return Result('Awake O_O', 0)

--- a/src/attackmate/schemas/sleep.py
+++ b/src/attackmate/schemas/sleep.py
@@ -1,4 +1,7 @@
 from typing import Literal
+from pydantic import computed_field
+from functools import cached_property
+from random import randint
 from attackmate.schemas.base import BaseCommand, StringNumber
 from attackmate.command import CommandRegistry
 
@@ -10,3 +13,11 @@ class SleepCommand(BaseCommand):
     seconds: StringNumber = '1'
     random: bool = False
     cmd: str = 'sleep'
+
+    @computed_field  # type: ignore[misc]
+    @cached_property
+    # calculates the actual sleep time based on whether random is enabled
+    def sleep_time(self) -> int:
+        if not self.random:
+            return int(self.seconds)
+        return randint(int(self.min_sec), int(self.seconds))


### PR DESCRIPTION
relates to #192 

- adds the actual `sleep_time` as `@computed_field` and `@cached_property` to the SleepCommand
output in attackmate.json:

´´´yaml
commands:
  - type: sleep
    seconds: 2

  - type: sleep
    seconds: 10
    min_sec: 3
    random: true

  - type: sleep
    seconds: 10
    min_sec: 3
    random: true
´´´

attackmate.json
{"start-datetime": "2026-01-21T12:56:04.045414", "type": "sleep", "cmd": "sleep", "parameters": {"only_if": null, "error_if": null, "error_if_not": null, "loop_if": null, "loop_if_not": null, "loop_count": "3", "exit_on_error": true, "save": null, "background": false, "kill_on_exit": true, "metadata": null, **"min_sec": "0", "seconds": "2", "random": false, "sleep_time": 2}**}
{"start-datetime": "2026-01-21T12:56:06.047318", "type": "sleep", "cmd": "sleep", "parameters": {"only_if": null, "error_if": null, "error_if_not": null, "loop_if": null, "loop_if_not": null, "loop_count": "3", "exit_on_error": true, "save": null, "background": false, "kill_on_exit": true, "metadata": null, **"min_sec": "3", "seconds": "10", "random": true, "sleep_time": 10**}}
{"start-datetime": "2026-01-21T12:56:16.058689", "type": "sleep", "cmd": "sleep", "parameters": {"only_if": null, "error_if": null, "error_if_not": null, "loop_if": null, "loop_if_not": null, "loop_count": "3", "exit_on_error": true, "save": null, "background": false, "kill_on_exit": true, "metadata": null, **"min_sec": "3", "seconds": "10", "random": true, "sleep_time": 3**}}

attackmate.log:
2026-01-21 12:56:04 INFO - Sleeping 2 seconds
2026-01-21 12:56:06 INFO - Sleeping 10 seconds
2026-01-21 12:56:16 INFO - Sleeping 3 seconds
