### PR TITLE
disabled Ssh algorithms

### DIFF
--- a/docs/source/playbook/commands/ssh.rst
+++ b/docs/source/playbook/commands/ssh.rst
@@ -85,6 +85,33 @@ Connection
    :default: ``60``
    :required: False
 
+.. confval:: disabled_algorithms
+
+   Mapping of algorithm categories to lists of algorithm names that paramiko
+   should not offer during negotiation. Useful when connecting to legacy SSH
+   servers that reject newer algorithm variants.
+
+   :type: dict[str, list[str]]
+   :default: ``None``
+   :required: False
+
+   The most common use case is forcing plain ``ssh-rsa`` when the server
+   (e.g. OpenSSH 4.7) does not support the ``rsa-sha2-256`` / ``rsa-sha2-512``
+   variants that modern paramiko prefers:
+
+   .. code-block:: yaml
+
+      commands:
+        - type: ssh
+          cmd: id
+          hostname: $METASPLOITABLE2
+          username: root
+          key_filename: /tmp/backdoor_key
+          disabled_algorithms:
+            pubkeys:
+              - rsa-sha2-256
+              - rsa-sha2-512
+
 .. confval:: clear_cache
 
    Clear all cached connection settings before this command runs, allowing a fresh

--- a/src/attackmate/executors/ssh/sshexecutor.py
+++ b/src/attackmate/executors/ssh/sshexecutor.py
@@ -36,6 +36,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
         self.passphrase = None
         self.key_filename = None
         self.timeout = 60
+        self.disabled_algorithms = None
         self.jmp_hostname = None
         self.jmp_port = 22
         self.jmp_username = self.username
@@ -55,6 +56,8 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             self.key_filename = command.key_filename
         if command.timeout:
             self.timeout = command.timeout
+        if command.disabled_algorithms is not None:
+            self.disabled_algorithms = command.disabled_algorithms
         if command.jmp_hostname:
             self.jmp_hostname = command.jmp_hostname
         if command.jmp_port:
@@ -79,6 +82,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             passphrase=self.passphrase,
             key_filename=self.key_filename,
             timeout=self.timeout,
+            disabled_algorithms=self.disabled_algorithms,
         )
 
         jmp.connect(**kwargs)
@@ -116,6 +120,7 @@ class SSHExecutor(BaseExecutor, SFTPFeature, Interactive):
             key_filename=self.key_filename,
             timeout=self.timeout,
             sock=jmp_sock,
+            disabled_algorithms=self.disabled_algorithms,
         )
         client.connect(**kwargs)
         if command.creates_session is not None:

--- a/src/attackmate/schemas/ssh.py
+++ b/src/attackmate/schemas/ssh.py
@@ -1,4 +1,4 @@
-from typing import Optional, Literal, List
+from typing import Optional, Literal, List, Dict
 from pydantic import ValidationInfo, field_validator
 from .base import BaseCommand, StringNumber
 from attackmate.command import CommandRegistry
@@ -22,6 +22,7 @@ class SSHBase(BaseCommand):
     session: Optional[str] = None
     clear_cache: bool = False
     timeout: float = 60
+    disabled_algorithms: Optional[Dict[str, List[str]]] = None
     jmp_hostname: Optional[str] = None
     jmp_port: StringNumber = None
     jmp_username: Optional[str] = None


### PR DESCRIPTION
  **Problem**                                                                       
   
  Connecting to legacy SSH servers (for example e.g. OpenSSH 4.7 on Metasploitable2, important for training puposes) with   
  key-based auth fails because paramiko negotiates rsa-sha2-256/rsa-sha2-512 by default, which old servers don't support.                                     
                  
  **Changes**

  - schemas/ssh.py: added ```disabled_algorithms: Optional[Dict[str, List[str]]] = None```                             
  - executors/ssh/sshexecutor.py: initialized self.disabled_algorithms = None in set_defaults(), cache it in cache_settings(), and pass it to  connect() calls 
  - updated docs
                                                                                
  **Usage**           

```
  - type: ssh
    hostname: $TARGET
    username: root
    key_filename: /tmp/backdoor_key
    disabled_algorithms:
      pubkeys:
        - rsa-sha2-256
        - rsa-sha2-512     
```                                                     
  
