### PR TITLE
docs: update installation and usage instructions to use uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,26 @@ Using pip:
 $ pip3 install attackmate
 ```
 
+Using uv (recommended):
+
+```
+$ curl -LsSf https://astral.sh/uv/install.sh | sh
+$ git clone https://github.com/ait-testbed/attackmate.git
+$ cd attackmate
+$ uv venv
+$ uv build
+$ uv pip install .
+```
+
 ## Execute
+
+Using uv (recommended):
+
+```
+$ uv run attackmate playbook.yml
+```
+
+Otherwise:
 
 ```
 $ attackmate playbook.yml

--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -61,6 +61,14 @@ First Run
 Now we can run the playbook using the following command:
 (We can supply the full path to the playbook, otherwise the parser tries to find it in the current working directory or in the folder /etc/attackmate/playbooks)
 
+If you installed AttackMate using ``uv`` (recommended), run:
+
+::
+
+  $ uv run attackmate --debug playbook.yml
+
+Otherwise, if you installed it manually or via pip, run:
+
 ::
 
   $ attackmate --debug playbook.yml

--- a/docs/source/installation/manual.rst
+++ b/docs/source/installation/manual.rst
@@ -37,6 +37,11 @@ Finally install attackmate and it's dependencies:
 
   $ pip3 install .
 
+.. note::
+
+   For a more modern installation approach, consider using ``uv`` package manager.
+   See :ref:`uv` for installation instructions using ``uv``.
+
 .. warning::
 
    Please note that you need to :ref:`sliver-fix` if you want


### PR DESCRIPTION
## Problem

The documentation currently references `python3 testbedrun` command which doesn't work. The project should use `uv` package manager for a more modern and reliable installation and execution approach.

## Fix

Updated documentation to include `uv` as the recommended installation and execution method:

1. **README.md**: Added `uv` installation and usage instructions as recommended approach
2. **docs/source/basic.rst**: Updated to show `uv run attackmate` as the recommended command
3. **docs/source/installation/manual.rst**: Added note suggesting `uv` as a modern alternative

## Related Issues

Fixes #222