### PR TITLE
fix background validator

### DIFF
--- a/src/attackmate/schemas/metasploit.py
+++ b/src/attackmate/schemas/metasploit.py
@@ -10,7 +10,9 @@ class MsfSessionCommand(BaseCommand):
     @field_validator('background')
     @classmethod
     def bg_not_implemented_yet(cls, v):
-        raise ValueError('background mode is unsupported for this command')
+        if v:
+            raise ValueError('background mode is unsupported for this command')
+        return v
 
     type: Literal['msf-session']
     cmd: str


### PR DESCRIPTION
fixes #242

Fix MsfSessionCommand background validator unconditionally rejecting all commands (API or MCP)

The bg_not_implemented_yet field validator on MsfSessionCommand raised ValueError on every instantiation, regardless of whether background was actually set to True. Since Pydantic runs all validators when building a model  including for default values  every msf-session command failed validation with a 422 Unprocessable Entity before reaching the executor.

**Direct playbooks:** AttackMate parses YAML and calls model_validate() with only the fields present in the YAML. Since background is not in the YAML, Pydantic treats it as "not provided" and by default in Pydantic v2 (validate_default=False)  does not run validators on fields that use their default value. The validator never fires.

**Via API/MCP:** FastAPI validates the JSON request body against RemotelyExecutableCommand, which is a Pydantic discriminated union. When resolving which subtype to use, Pydantic explicitly constructs the full model including all fields, causing the background validator to run even on the default False value. triggers the unconditional raise → 422.

Fixed by adding a if v: guard so the error is only raised when background=True is explicitly requested, and returning the value otherwise.

```
# Before
  def bg_not_implemented_yet(cls, v):
      raise ValueError('background mode is unsupported for this command')
```
```

# After
  def bg_not_implemented_yet(cls, v):
      if v:
          raise ValueError('background mode is unsupported for this command')
      return v
```

# Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->


# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] This Pull-Request goes to the **development** branch.
- [ ] I have successfully run prek locally.
- [ ] I have added tests to cover my changes.
- [ ] I have linked the issue-id to the task-description.
- [ ] I have performed a self-review of my own code.
