### PR TITLE
reset command_timeout on interactive command when output is received …

### DIFF
--- a/src/attackmate/executors/ssh/interactfeature.py
+++ b/src/attackmate/executors/ssh/interactfeature.py
@@ -19,8 +19,7 @@ class Interactive:
                     self.logger.debug('found prompt!')
                     self.timer = None
                     return True
-        else:
-            self.set_timer()
+        self.set_timer()
         return False
 
     def check_timer(self, seconds: int) -> bool:

--- a/src/attackmate/executors/ssh/interactfeature.py
+++ b/src/attackmate/executors/ssh/interactfeature.py
@@ -13,12 +13,19 @@ class Interactive:
         self.logger = logging.getLogger('playbook')
 
     def check_prompt(self, output: str, prompts: list[str]) -> bool:
-        if output and prompts:
-            for p in prompts:
-                if output.endswith(p):
-                    self.logger.debug('found prompt!')
-                    self.timer = None
-                    return True
+        if not output:
+            return False
+
+        if not prompts:
+            self.set_timer()
+            return False
+
+        for p in prompts:
+            if output.endswith(p):
+                self.logger.debug('found prompt!')
+                self.timer = None
+                return True
+
         self.set_timer()
         return False
 

--- a/test/units/test_interactfeature.py
+++ b/test/units/test_interactfeature.py
@@ -1,0 +1,33 @@
+import time
+from attackmate.executors.ssh.interactfeature import Interactive
+
+
+class TestCheckPrompt:
+    def setup_method(self):
+        self.interactive = Interactive()
+        self.interactive.set_timer()
+
+    def test_no_prompts_configured_resets_timer(self):
+        before = self.interactive.timer
+        time.sleep(0.05)
+        self.interactive.check_prompt('some output', [])
+        assert self.interactive.timer > before
+
+    def test_prompt_not_matched_resets_timer(self):
+        before = self.interactive.timer
+        time.sleep(0.05)
+        result = self.interactive.check_prompt('still running...', ['$ '])
+        assert result is False
+        assert self.interactive.timer > before
+
+    def test_prompt_matched_clears_timer_and_returns_true(self):
+        result = self.interactive.check_prompt('root@host:~$ ', ['$ '])
+        assert result is True
+        assert self.interactive.timer is None
+
+    def test_empty_output_on_channel_eof_does_not_reset_timer(self):
+        before = self.interactive.timer
+        time.sleep(0.05)
+        result = self.interactive.check_prompt('', ['$ '])
+        assert result is False
+        assert self.interactive.timer == before


### PR DESCRIPTION
…also when prompt is set

# Task
#253

When prompts were configured (which is the default: ['$ ', '# ', '> ']), the interactive mode timer was only reset via the else branch of check_prompt, which was never reached when prompts were set. This caused command_timeout to count from when the command was dispatched rather than from the last received output, silently cutting off long-running commands
Moving set_timer() outside the else block ensures the timer resets on every received chunk unless a prompt match is found and the loop exits.


# Description
fix: reset interactive SSH timeout on every received output chunk, not only when no prompts are configured

check_prompt is now:
- Empty output (EOF) → timer unchanged, return False
-   No prompts configured → reset timer, return False
- Prompt matched → timer = None (stops loop), return True
- Prompt not matched → reset timer, return False



# How Has This Been Tested?
<!-- Please describe how you tested your changes -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [ ] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
