### PR TITLE
Clear regex output variables

### DIFF
--- a/src/attackmate/executors/common/regexexecutor.py
+++ b/src/attackmate/executors/common/regexexecutor.py
@@ -43,6 +43,11 @@ class RegExExecutor(BaseExecutor):
         if not matches:
             self.logger.debug('no match!')
             self.varstore.set_variable('REGEX_MATCHES_LIST', [])
+            # Clear the output variables so a stale value from a previous
+            # loop iteration doesn't produce a false positive when the
+            # current input has no match.
+            for k in outputvars:
+                self.varstore.set_variable(k, '')
             return
 
         for k, v in outputvars.items():
@@ -73,7 +78,7 @@ class RegExExecutor(BaseExecutor):
             if m3 is not None and isinstance(m3, Match):
                 self.forge_and_register_variables(command.output, m3.group())
             else:
-                self.varstore.set_variable('REGEX_MATCHES_LIST', [])
+                self.forge_and_register_variables(command.output, None)
         if command.mode == 'sub':
             if command.replace:
                 replaced = re.sub(command.cmd, command.replace, self.varstore.get_str(command.input))

--- a/test/units/test_regexexecutor.py
+++ b/test/units/test_regexexecutor.py
@@ -178,8 +178,8 @@ class TestRegExExecutor:
 
     @pytest.mark.asyncio
     async def test_exec_cmd_search_no_match_clears_stale_value(self):
-        # Regression: in a loop a previous iteration may have set the output
-        # variable. A subsequent no-match must clear it, not leave the old value.
+        # Regression: in a loop a previous iteration might set output
+        # variable. A following no-match must clear it, not leave the old value.
         self.varstore.set_variable('PORT_STATUS', 'open')
         self.varstore.set_variable('input_var', 'closed')
         command = RegExCommand(

--- a/test/units/test_regexexecutor.py
+++ b/test/units/test_regexexecutor.py
@@ -129,7 +129,7 @@ class TestRegExExecutor:
             output={'output_var': 'Found: $MATCH_0'},
         )
         await self.executor._exec_cmd(command)
-        assert 'output_var' not in self.varstore.variables
+        assert self.varstore.get_variable('output_var') == ''
         assert self.varstore.get_variable('REGEX_MATCHES_LIST') == []
 
     @pytest.mark.asyncio
@@ -156,7 +156,7 @@ class TestRegExExecutor:
             output={'output_var': 'Found: $MATCH_0'},
         )
         await self.executor._exec_cmd(command)
-        assert 'output_var' not in self.varstore.variables
+        assert self.varstore.get_variable('output_var') == ''
         assert self.varstore.get_variable('REGEX_MATCHES_LIST') == []
 
     @pytest.mark.asyncio
@@ -175,3 +175,20 @@ class TestRegExExecutor:
         await self.executor._exec_cmd(command)
         assert self.varstore.get_variable('output_var') == 'Replaced: no matches here'
         assert self.varstore.get_variable('REGEX_MATCHES_LIST') == ['no matches here']
+
+    @pytest.mark.asyncio
+    async def test_exec_cmd_search_no_match_clears_stale_value(self):
+        # Regression: in a loop a previous iteration may have set the output
+        # variable. A subsequent no-match must clear it, not leave the old value.
+        self.varstore.set_variable('PORT_STATUS', 'open')
+        self.varstore.set_variable('input_var', 'closed')
+        command = RegExCommand(
+            type='regex',
+            cmd='open',
+            mode='search',
+            input='input_var',
+            output={'PORT_STATUS': '$MATCH_0'},
+        )
+        await self.executor._exec_cmd(command)
+        assert self.varstore.get_variable('PORT_STATUS') == ''
+        assert self.varstore.get_variable('REGEX_MATCHES_LIST') == []


### PR DESCRIPTION
# Task
#255

# Description
Fix
- register_outputvars: on no-match, clear each declared output variable to '' before returning.
- search no-match branch now routes through forge_and_register_variables(command.output, None) --> same clearing path.

Only the variables named in that command's own output: block are affected. No other variables in the VariableStore are touched

Tests
Updated findall/search no-match tests to expect the cleared '' value.
- Added test_exec_cmd_search_no_match_clears_stale_value reproducing the loop scenario.


# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [x] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
