### PR TITLE
fix(shell): don't let non-UTF-8 command output kill the playbook

### DIFF
--- a/src/attackmate/executors/shell/shellexecutor.py
+++ b/src/attackmate/executors/shell/shellexecutor.py
@@ -74,7 +74,13 @@ class ShellExecutor(BaseExecutor):
             proc.kill()
             output, error = proc.communicate()
         output += error
-        return output.decode()
+        # Command output is arbitrary bytes, not guaranteed UTF-8. A strict decode
+        # raises UnicodeDecodeError, which nothing between here and main() catches -
+        # so one undecodable byte terminates the whole playbook rather than failing
+        # this step. Replace undecodable bytes instead: output is used for logging,
+        # error_if matching and save-to-file, none of which need a lossless
+        # round-trip.
+        return output.decode(errors='replace')
 
     def popen_interactive(
         self, proc: subprocess.Popen, cmd: bytes, timeout: int = 5, read: bool = True
@@ -96,7 +102,8 @@ class ShellExecutor(BaseExecutor):
                     outline += tmp
                     begin = datetime.now()  # reset timer when data comes
 
-        return outline.decode()
+        # Same reasoning as popen_noninteractive: never let output bytes end the run.
+        return outline.decode(errors='replace')
 
     async def _exec_cmd(self, command: ShellCommand) -> Result:
         try:

--- a/test/units/test_shellexecutor.py
+++ b/test/units/test_shellexecutor.py
@@ -99,3 +99,51 @@ async def test_execution_of_hex_command(shell_executor):
 
     result = await shell_executor._exec_cmd(command)
     assert result.stdout == 'id\n'
+
+
+@pytest.mark.asyncio
+async def test_non_utf8_output_does_not_raise(mock_popen, shell_executor):
+    """A command emitting a non-UTF-8 byte must not terminate the playbook.
+
+    0xc9 without a continuation byte is not valid UTF-8. A strict decode raises
+    UnicodeDecodeError, which nothing catches between _exec_cmd and main().
+    """
+    mock_open_proc, mock_popen_instance = mock_popen
+    mock_popen_instance.communicate.return_value = (b'ok\xc9done', b'')
+    with patch.object(shell_executor, 'open_proc', mock_open_proc):
+
+        command = ShellCommand(
+            type='shell',
+            cmd="printf 'ok\\311done'",
+            bin=False,
+        )
+        result = await shell_executor._exec_cmd(command)
+
+        assert result.stdout == 'ok�done'
+
+
+def test_popen_interactive_non_utf8_output_does_not_raise(shell_executor):
+    """The interactive read path decodes separately and needs the same treatment."""
+    reads = [b'ok\xc9done']
+
+    def fake_read(_stdout):
+        return reads.pop(0) if reads else b''
+
+    mock_popen_instance = MagicMock()
+    with patch.object(shell_executor, 'non_block_read', side_effect=fake_read):
+        output = shell_executor.popen_interactive(mock_popen_instance, b'cmd\n', timeout=1)
+
+    assert output == 'ok�done'
+
+
+@pytest.mark.asyncio
+async def test_execution_of_command_with_non_utf8_output(shell_executor):
+    """End to end: /bin/sh printf has no \\xHH, so the octal escape is the portable one."""
+    command = ShellCommand(
+        type='shell',
+        cmd="printf 'ok\\311done'",
+        bin=False,
+    )
+
+    result = await shell_executor._exec_cmd(command)
+    assert result.stdout == 'ok�done'


### PR DESCRIPTION
ShellExecutor decoded command output with a strict UTF-8 decode. Command output is arbitrary bytes, so any command emitting a non-UTF-8 byte raised UnicodeDecodeError. Nothing catches it between _exec_cmd and main(), so the exception terminates the entire playbook rather than failing the one step.

Both read paths are affected: popen_noninteractive on its combined stdout+stderr, and popen_interactive on its non-blocking read.

Use errors='replace' so undecodable bytes become U+FFFD and execution continues. Output is used for logging, error_if/error_if_not matching and save-to-file; none of those require a lossless round-trip, and a replacement character is strictly more useful than losing the run.

Adds three regression tests, one per read path plus an end-to-end shell execution. All three fail on the strict decode and pass with the fix.

Encountered with a PHP filter-chain response containing 0xc9, which ended a 40-step playbook at step 6.

# Task
<!-- Please add link a relevant issue or task -->

# Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [x] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
